### PR TITLE
feat: Order 도메인 모델 구현

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -143,12 +143,13 @@ reviews:
         - /internal/api/* 경로 컨트롤러는 별도 패키지로 분리하고 외부 노출 방지
 
         [12] Exception Handling
-        - 모든 도메인 예외는 common 모듈의 ErrorCodeSpec 인터페이스 기반 enum 사용
-          (예: OrderErrorCode)
-        - Order 도메인은 OrderException 단일 클래스 사용 권장
+        - 도메인 예외는 common 모듈의 CustomException 또는 ErrorCodeSpec 인터페이스를 활용해야 한다
+        - 비즈니스별 도메인 예외 클래스 분리 허용 — 단, 모두 도메인 base exception을 상속해야 함
+          (예: OrderException(abstract base) → OrderNotFoundException, InvalidStatusTransitionException, SelfPurchaseException)
+        - 도메인 base exception은 abstract로 두고 각 비즈니스 케이스마다 구체 클래스로 정의
         - IllegalArgumentException, IllegalStateException 등 표준 예외를 도메인 로직에서 직접 사용 시 지적
-        - 에러 메시지는 ErrorCode에서 관리하며, Exception에서 별도 문자열 정의 금지
-          (예: throw new OrderException(OrderErrorCode.INVALID_STATUS))
+        - 예외 메시지는 도메인 예외 클래스 생성자 또는 ErrorCodeSpec에서 관리, 호출부에서 임의 문자열 메시지 사용 금지
+        - 에러 코드(HTTP status, type URI 등)는 common의 ErrorCodeSpec 인터페이스를 통해 일관성 유지
 
         [13] Logging & Security
         - 민감 정보 로그 출력 차단 (사용자 ID, 카드번호, PG 토큰, 결제 키 등)

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -79,8 +79,11 @@ reviews:
 
         [3] VO / 타입 안정성
         - VO/DTO/Event는 record 사용 강제
-        - Primitive Obsession 금지 → Strong Type VO 사용
-          (OrderId, BuyerId, SellerId, ProductId, Money 등)
+        - Primitive Obsession 금지 → Strong Type VO 사용 (OrderId, Money 등)
+        - cross-domain 식별자(buyerId/sellerId/productId 등)는 다음 중 하나로 처리 (사용 맥락에 따라 선택):
+          * snapshot VO에 포함 (예: Buyer(UUID id, String name))
+          * 강한 타입 분리 (예: BuyerId 별도 VO)
+          → snapshot VO 외부에서 식별자를 단독으로 다루는 유스케이스가 있으면 강한 타입 권장
         - record는 compact constructor에서 validation 필수
           (단, 이벤트 메시지 record는 신뢰성 있는 데이터로 간주하여 검증 면제 가능)
         - 금액(Money)은 BigDecimal 또는 long 만 사용. double / float 금지
@@ -143,13 +146,16 @@ reviews:
         - /internal/api/* 경로 컨트롤러는 별도 패키지로 분리하고 외부 노출 방지
 
         [12] Exception Handling
-        - 도메인 예외는 common 모듈의 CustomException 또는 ErrorCodeSpec 인터페이스를 활용해야 한다
+        - 도메인 예외는 common 모듈의 CustomException을 상속한다
+          → CustomException 자체가 HttpStatus를 시그니처에 포함하므로, 도메인 예외 생성자에 HttpStatus 인자 직접 사용 허용
+            (룰 [1] "도메인의 Spring 의존성 차단"의 예외 — common 추상화 경유 시 한정)
         - 비즈니스별 도메인 예외 클래스 분리 허용 — 단, 모두 도메인 base exception을 상속해야 함
           (예: OrderException(abstract base) → OrderNotFoundException, InvalidStatusTransitionException, SelfPurchaseException)
         - 도메인 base exception은 abstract로 두고 각 비즈니스 케이스마다 구체 클래스로 정의
-        - IllegalArgumentException, IllegalStateException 등 표준 예외를 도메인 로직에서 직접 사용 시 지적
-        - 예외 메시지는 도메인 예외 클래스 생성자 또는 ErrorCodeSpec에서 관리, 호출부에서 임의 문자열 메시지 사용 금지
-        - 에러 코드(HTTP status, type URI 등)는 common의 ErrorCodeSpec 인터페이스를 통해 일관성 유지
+        - IllegalArgumentException, IllegalStateException, NullPointerException 등 표준 예외를 도메인 로직에서 직접 사용 시 지적
+          (Objects.requireNonNull 포함 — null 검증도 도메인 예외로 처리)
+        - 예외 메시지는 도메인 예외 클래스 생성자에서 관리, 호출부에서 임의 문자열 메시지 사용 금지
+        - 에러 코드 카탈로그가 필요해질 때 common의 ErrorCodeSpec 인터페이스 활용 (선택)
 
         [13] Logging & Security
         - 민감 정보 로그 출력 차단 (사용자 ID, 카드번호, PG 토큰, 결제 키 등)

--- a/src/main/java/com/trustamarket/orderservice/order/domain/exception/AmountMismatchException.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/exception/AmountMismatchException.java
@@ -1,0 +1,13 @@
+package com.trustamarket.orderservice.order.domain.exception;
+
+import org.springframework.http.HttpStatus;
+
+// 400 Bad Request — totalAmount != productPrice + shippingFee (도메인 invariant 위반)
+public class AmountMismatchException extends OrderException {
+
+    public AmountMismatchException(long expected, long actual) {
+        super(HttpStatus.BAD_REQUEST,
+                "총액 계산이 맞지 않습니다. expected=%d, actual=%d".formatted(expected, actual),
+                "totalAmount");
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/exception/CancelNotAllowedException.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/exception/CancelNotAllowedException.java
@@ -1,0 +1,14 @@
+package com.trustamarket.orderservice.order.domain.exception;
+
+import com.trustamarket.orderservice.order.domain.model.OrderStatus;
+import org.springframework.http.HttpStatus;
+
+// 409 Conflict — 배송 시작 후/종결 상태에서 취소 시도
+public class CancelNotAllowedException extends OrderException {
+
+    public CancelNotAllowedException(OrderStatus current) {
+        super(HttpStatus.CONFLICT,
+                "현재 상태(%s)에서는 취소가 불가합니다. 배송 시작 후에는 반송을 사용하세요.".formatted(current),
+                "status");
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/exception/InvalidIdException.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/exception/InvalidIdException.java
@@ -1,0 +1,13 @@
+package com.trustamarket.orderservice.order.domain.exception;
+
+import org.springframework.http.HttpStatus;
+
+// 400 Bad Request — 식별자 VO(OrderId/OrderReturnId/BuyerId/SellerId/ProductId)의 value null 검증 실패
+public class InvalidIdException extends OrderException {
+
+    public InvalidIdException(String fieldName) {
+        super(HttpStatus.BAD_REQUEST,
+                "%s 값은 필수입니다.".formatted(fieldName),
+                fieldName);
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/exception/InvalidMoneyException.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/exception/InvalidMoneyException.java
@@ -2,12 +2,18 @@ package com.trustamarket.orderservice.order.domain.exception;
 
 import org.springframework.http.HttpStatus;
 
-// 400 Bad Request — Money VO 음수 검증 실패
+// 400 Bad Request — Money VO 검증 실패 (음수 또는 null)
 public class InvalidMoneyException extends OrderException {
 
     public InvalidMoneyException(long value) {
         super(HttpStatus.BAD_REQUEST,
                 "금액은 0 이상이어야 합니다. 입력값: " + value,
                 "amount");
+    }
+
+    public InvalidMoneyException(String field) {
+        super(HttpStatus.BAD_REQUEST,
+                "금액(%s)은 null일 수 없습니다.".formatted(field),
+                field);
     }
 }

--- a/src/main/java/com/trustamarket/orderservice/order/domain/exception/InvalidMoneyException.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/exception/InvalidMoneyException.java
@@ -16,4 +16,11 @@ public class InvalidMoneyException extends OrderException {
                 "금액(%s)은 null일 수 없습니다.".formatted(field),
                 field);
     }
+
+    // 산술 오버플로우 — long 범위를 벗어남
+    public InvalidMoneyException(String operation, long left, long right) {
+        super(HttpStatus.BAD_REQUEST,
+                "금액 %s 결과가 long 범위를 초과했습니다. left=%d, right=%d".formatted(operation, left, right),
+                "amount");
+    }
 }

--- a/src/main/java/com/trustamarket/orderservice/order/domain/exception/InvalidMoneyException.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/exception/InvalidMoneyException.java
@@ -1,0 +1,13 @@
+package com.trustamarket.orderservice.order.domain.exception;
+
+import org.springframework.http.HttpStatus;
+
+// 400 Bad Request — Money VO 음수 검증 실패
+public class InvalidMoneyException extends OrderException {
+
+    public InvalidMoneyException(long value) {
+        super(HttpStatus.BAD_REQUEST,
+                "금액은 0 이상이어야 합니다. 입력값: " + value,
+                "amount");
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/exception/InvalidNameException.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/exception/InvalidNameException.java
@@ -1,0 +1,13 @@
+package com.trustamarket.orderservice.order.domain.exception;
+
+import org.springframework.http.HttpStatus;
+
+// 400 Bad Request — Snapshot VO(BuyerSnapshot/SellerSnapshot/ProductSnapshot)의 name 필드 검증 실패
+public class InvalidNameException extends OrderException {
+
+    public InvalidNameException(String fieldName) {
+        super(HttpStatus.BAD_REQUEST,
+                "%s은(는) 비어있을 수 없습니다.".formatted(fieldName),
+                fieldName);
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/exception/InvalidReasonException.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/exception/InvalidReasonException.java
@@ -1,15 +1,15 @@
 package com.trustamarket.orderservice.order.domain.exception;
 
+import com.trustamarket.orderservice.order.domain.model.Reason;
 import org.springframework.http.HttpStatus;
 
-// 400 Bad Request — Reason VO 검증 실패 (blank 또는 200자 초과)
+// 400 Bad Request — Reason VO 검증 실패 (blank 또는 max length 초과)
+// max length는 Reason.MAX_LENGTH를 단일 소스로 참조 (이중 관리 방지)
 public class InvalidReasonException extends OrderException {
-
-    private static final int MAX_LENGTH = 200;
 
     public InvalidReasonException() {
         super(HttpStatus.BAD_REQUEST,
-                "사유는 비어있을 수 없으며 최대 %d자입니다.".formatted(MAX_LENGTH),
+                "사유는 비어있을 수 없으며 최대 %d자입니다.".formatted(Reason.MAX_LENGTH),
                 "reason");
     }
 }

--- a/src/main/java/com/trustamarket/orderservice/order/domain/exception/InvalidReasonException.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/exception/InvalidReasonException.java
@@ -1,0 +1,15 @@
+package com.trustamarket.orderservice.order.domain.exception;
+
+import org.springframework.http.HttpStatus;
+
+// 400 Bad Request — Reason VO 검증 실패 (blank 또는 200자 초과)
+public class InvalidReasonException extends OrderException {
+
+    private static final int MAX_LENGTH = 200;
+
+    public InvalidReasonException() {
+        super(HttpStatus.BAD_REQUEST,
+                "사유는 비어있을 수 없으며 최대 %d자입니다.".formatted(MAX_LENGTH),
+                "reason");
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/exception/InvalidStatusTransitionException.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/exception/InvalidStatusTransitionException.java
@@ -1,0 +1,15 @@
+package com.trustamarket.orderservice.order.domain.exception;
+
+import com.trustamarket.orderservice.order.domain.model.OrderAction;
+import com.trustamarket.orderservice.order.domain.model.OrderStatus;
+import org.springframework.http.HttpStatus;
+
+// 409 Conflict — 허용되지 않는 상태 전이 시도
+public class InvalidStatusTransitionException extends OrderException {
+
+    public InvalidStatusTransitionException(OrderStatus from, OrderAction action) {
+        super(HttpStatus.CONFLICT,
+                "%s 상태에서 %s 액션은 허용되지 않습니다.".formatted(from, action),
+                "status");
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/exception/InvalidTimestampException.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/exception/InvalidTimestampException.java
@@ -1,0 +1,13 @@
+package com.trustamarket.orderservice.order.domain.exception;
+
+import org.springframework.http.HttpStatus;
+
+// 400 Bad Request — 도메인 메서드의 시각 인자(Instant) null 차단
+public class InvalidTimestampException extends OrderException {
+
+    public InvalidTimestampException(String field) {
+        super(HttpStatus.BAD_REQUEST,
+                "시각(%s)은 null일 수 없습니다.".formatted(field),
+                field);
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/exception/OrderException.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/exception/OrderException.java
@@ -1,0 +1,18 @@
+package com.trustamarket.orderservice.order.domain.exception;
+
+import com.trustamarket.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+// Order 도메인의 모든 비즈니스 예외의 base 에러
+// 비즈니스별 구체 클래스(OrderNotFoundException 등)가 이를 상속함
+// Catch by type 가능하도록 abstract로 class 설정했음!
+public abstract class OrderException extends CustomException {
+
+    protected OrderException(HttpStatus status, String message) {
+        super(status, message);
+    }
+
+    protected OrderException(HttpStatus status, String message, String field) {
+        super(status, message, field);
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/exception/OrderNotFoundException.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/exception/OrderNotFoundException.java
@@ -1,0 +1,13 @@
+package com.trustamarket.orderservice.order.domain.exception;
+
+import org.springframework.http.HttpStatus;
+
+import java.util.UUID;
+
+// 404 Not Found — 주문 리소스 부재
+public class OrderNotFoundException extends OrderException {
+
+    public OrderNotFoundException(UUID orderId) {
+        super(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다: " + orderId);
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/exception/RestoreStateMismatchException.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/exception/RestoreStateMismatchException.java
@@ -1,0 +1,16 @@
+package com.trustamarket.orderservice.order.domain.exception;
+
+import org.springframework.http.HttpStatus;
+
+// 400 Bad Request — 복원된 주문의 상태별 메타데이터 불변식 위반
+// 정상 도메인 행위 메서드를 거치면 발생할 수 없는 조합 → DB 변조 감지
+// (예: CONFIRMED인데 confirmedAt == null, CANCELLED인데 cancelReason == null,
+//      deletedAt/deletedBy가 반쪽만 채워진 상태 등)
+public class RestoreStateMismatchException extends OrderException {
+
+    public RestoreStateMismatchException(String detail) {
+        super(HttpStatus.BAD_REQUEST,
+                "복원된 주문의 상태와 메타데이터가 일치하지 않습니다: " + detail,
+                "status");
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/exception/RestoreStateMismatchException.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/exception/RestoreStateMismatchException.java
@@ -1,16 +1,44 @@
 package com.trustamarket.orderservice.order.domain.exception;
 
+import com.trustamarket.orderservice.order.domain.model.OrderStatus;
 import org.springframework.http.HttpStatus;
 
 // 400 Bad Request — 복원된 주문의 상태별 메타데이터 불변식 위반
 // 정상 도메인 행위 메서드를 거치면 발생할 수 없는 조합 → DB 변조 감지
-// (예: CONFIRMED인데 confirmedAt == null, CANCELLED인데 cancelReason == null,
-//      deletedAt/deletedBy가 반쪽만 채워진 상태 등)
+// 메시지·field는 정적 팩터리에서 고정 (호출부 자유 문자열 금지)
 public class RestoreStateMismatchException extends OrderException {
 
-    public RestoreStateMismatchException(String detail) {
-        super(HttpStatus.BAD_REQUEST,
-                "복원된 주문의 상태와 메타데이터가 일치하지 않습니다: " + detail,
-                "status");
+    private RestoreStateMismatchException(String message, String field) {
+        super(HttpStatus.BAD_REQUEST, message, field);
+    }
+
+    public static RestoreStateMismatchException missingConfirmedAt(OrderStatus status) {
+        return new RestoreStateMismatchException(
+                "%s 상태는 confirmedAt이 필수입니다.".formatted(status),
+                "confirmedAt");
+    }
+
+    public static RestoreStateMismatchException missingCancelReason(OrderStatus status) {
+        return new RestoreStateMismatchException(
+                "%s 상태는 cancelReason이 필수입니다.".formatted(status),
+                "cancelReason");
+    }
+
+    public static RestoreStateMismatchException missingReturnReason(OrderStatus status) {
+        return new RestoreStateMismatchException(
+                "%s 상태는 returnReason이 필수입니다.".formatted(status),
+                "returnReason");
+    }
+
+    public static RestoreStateMismatchException missingRejectReason() {
+        return new RestoreStateMismatchException(
+                "RETURN_REJECTED 상태는 rejectReason이 필수입니다.",
+                "rejectReason");
+    }
+
+    public static RestoreStateMismatchException inconsistentDeletionMetadata() {
+        return new RestoreStateMismatchException(
+                "deletedAt/deletedBy는 동시에 채워져야 합니다.",
+                "deletedAt");
     }
 }

--- a/src/main/java/com/trustamarket/orderservice/order/domain/exception/ReturnDecisionForbiddenException.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/exception/ReturnDecisionForbiddenException.java
@@ -1,0 +1,11 @@
+package com.trustamarket.orderservice.order.domain.exception;
+
+import org.springframework.http.HttpStatus;
+
+// 403 Forbidden — ADMIN 외 권한이 반송 승인/거절 시도
+public class ReturnDecisionForbiddenException extends OrderException {
+
+    public ReturnDecisionForbiddenException() {
+        super(HttpStatus.FORBIDDEN, "반송 승인/거절 결정 권한이 없습니다. ADMIN 전용입니다.");
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/exception/ReturnNotAllowedException.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/exception/ReturnNotAllowedException.java
@@ -1,0 +1,14 @@
+package com.trustamarket.orderservice.order.domain.exception;
+
+import com.trustamarket.orderservice.order.domain.model.OrderStatus;
+import org.springframework.http.HttpStatus;
+
+// 409 Conflict — 배송 시작 전/종결 상태에서 반송 요청 시도
+public class ReturnNotAllowedException extends OrderException {
+
+    public ReturnNotAllowedException(OrderStatus current) {
+        super(HttpStatus.CONFLICT,
+                "현재 상태(%s)에서는 반송 요청이 불가합니다. 배송 시작 후에만 가능합니다.".formatted(current),
+                "status");
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/exception/SelfPurchaseException.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/exception/SelfPurchaseException.java
@@ -1,0 +1,11 @@
+package com.trustamarket.orderservice.order.domain.exception;
+
+import org.springframework.http.HttpStatus;
+
+// 400 Bad Request — 자기 상품 구매 시도 (도메인 invariant 위반)
+public class SelfPurchaseException extends OrderException {
+
+    public SelfPurchaseException() {
+        super(HttpStatus.BAD_REQUEST, "자신의 상품은 구매할 수 없습니다.", "buyerId");
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/Buyer.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/Buyer.java
@@ -1,0 +1,24 @@
+package com.trustamarket.orderservice.order.domain.model;
+
+import com.trustamarket.orderservice.order.domain.exception.InvalidIdException;
+import com.trustamarket.orderservice.order.domain.exception.InvalidNameException;
+
+import java.util.UUID;
+
+// 구매자 snapshot — 주문 시점의 id + name을 보존
+// User 도메인의 이름이 추후 변경되어도 Order의 buyer 정보는 변하지 않음 (audit/무결성)
+public record Buyer(UUID id, String name) {
+
+    public Buyer {
+        if (id == null) {
+            throw new InvalidIdException("buyerId");
+        }
+        if (name == null || name.isBlank()) {
+            throw new InvalidNameException("buyerName");
+        }
+    }
+
+    public static Buyer of(UUID id, String name) {
+        return new Buyer(id, name);
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/Money.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/Money.java
@@ -1,0 +1,32 @@
+package com.trustamarket.orderservice.order.domain.model;
+
+import com.trustamarket.orderservice.order.domain.exception.InvalidMoneyException;
+
+// 금액 VO, 원화 정수 기준 (long)
+// 음수 거부 + plus/minus(쓸모가 있을까?) 메서드
+public record Money(long value) {
+
+    public static final Money ZERO = new Money(0);
+
+    public Money {
+        if (value < 0) {
+            throw new InvalidMoneyException(value);
+        }
+    }
+
+    public static Money of(long value) {
+        return new Money(value);
+    }
+
+    public Money plus(Money other) {
+        return new Money(this.value + other.value);
+    }
+
+    public Money minus(Money other) {
+        return new Money(this.value - other.value);
+    }
+
+    public boolean equalsAmount(Money other) {
+        return this.value == other.value;
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/Money.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/Money.java
@@ -3,7 +3,7 @@ package com.trustamarket.orderservice.order.domain.model;
 import com.trustamarket.orderservice.order.domain.exception.InvalidMoneyException;
 
 // 금액 VO, 원화 정수 기준 (long)
-// 음수 거부 + plus/minus(쓸모가 있을까?) 메서드
+// 음수 거부 + plus/minus 메서드 (null 인자는 도메인 예외로 차단 — NPE 회피)
 public record Money(long value) {
 
     public static final Money ZERO = new Money(0);
@@ -19,14 +19,23 @@ public record Money(long value) {
     }
 
     public Money plus(Money other) {
+        if (other == null) {
+            throw new InvalidMoneyException("other");
+        }
         return new Money(this.value + other.value);
     }
 
     public Money minus(Money other) {
+        if (other == null) {
+            throw new InvalidMoneyException("other");
+        }
         return new Money(this.value - other.value);
     }
 
     public boolean equalsAmount(Money other) {
+        if (other == null) {
+            throw new InvalidMoneyException("other");
+        }
         return this.value == other.value;
     }
 }

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/Money.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/Money.java
@@ -22,14 +22,22 @@ public record Money(long value) {
         if (other == null) {
             throw new InvalidMoneyException("other");
         }
-        return new Money(this.value + other.value);
+        try {
+            return new Money(Math.addExact(this.value, other.value));
+        } catch (ArithmeticException overflow) {
+            throw new InvalidMoneyException("plus", this.value, other.value);
+        }
     }
 
     public Money minus(Money other) {
         if (other == null) {
             throw new InvalidMoneyException("other");
         }
-        return new Money(this.value - other.value);
+        try {
+            return new Money(Math.subtractExact(this.value, other.value));
+        } catch (ArithmeticException overflow) {
+            throw new InvalidMoneyException("minus", this.value, other.value);
+        }
     }
 
     public boolean equalsAmount(Money other) {

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/Order.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/Order.java
@@ -1,0 +1,254 @@
+package com.trustamarket.orderservice.order.domain.model;
+
+import com.trustamarket.orderservice.order.domain.exception.AmountMismatchException;
+import com.trustamarket.orderservice.order.domain.exception.SelfPurchaseException;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+// Order Aggregate Root
+// 상태 전이는 OrderTransition.apply()로 위임
+// 불변식: seller != buyer, totalAmount = product.price + shippingFee
+// BaseUserEntity 미상속 — JPA 의존성 도메인 침범 차단
+// audit 필드는 보유만 하고 자동 채움은 JPA Entity(adapter)가 BaseUserEntity 상속해 처리.
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class Order {
+
+    // 식별자
+    private OrderId id;
+
+    // Snapshot (cross-domain 데이터, 주문 시점에 freeze)
+    private Buyer buyer;
+    private Seller seller;
+    private Product product;
+
+    // 정책
+    private OrderType type;
+    private OrderStatus status;
+    private Money shippingFee;
+    private Money totalAmount;       // = product.price + shippingFee
+
+    // 사유 (nullable, 해당 액션 발생 시 채워짐)
+    private Reason cancelReason;
+    private Reason returnReason;
+    private Reason rejectReason;
+
+    // 시간 / Audit (common BaseUserEntity 패턴 매칭)
+    // JPA 어댑터에서 BaseUserEntity 상속 + AuditorAware로 자동 채움 예정.
+    // 도메인은 필드만 들고 있음 (적극 관리 X — application/adapter가 채움).
+    private Instant createdAt;
+    private Instant updatedAt;
+    private Instant deletedAt;       // nullable, soft delete 시 채움
+    private UUID createdBy;
+    private UUID updatedBy;
+    private UUID deletedBy;          // nullable
+
+    // 비즈니스 시간
+    private Instant confirmedAt;     // nullable, CONFIRMED 전이 시 채움
+
+    // 동시성 제어
+    private int version;
+
+    // 정적 팩토리 — 신규 주문 생성
+
+    // 새 주문을 생성. 초기 상태는 REQUESTED.
+    // totalAmount는 자동 계산 (product.price + shippingFee)
+    // createdAt/updatedAt/createdBy/updatedBy 는 JPA Auditing이 자동 채움 (어댑터 레이어)
+    public static Order create(
+            Buyer buyer,
+            Seller seller,
+            Product product,
+            OrderType type,
+            Money shippingFee
+    ) {
+        validateInvariants(buyer, seller);
+
+        Order order = new Order();
+        order.id = OrderId.generate();
+        order.buyer = buyer;
+        order.seller = seller;
+        order.product = product;
+        order.type = type;
+        order.status = OrderStatus.REQUESTED;
+        order.shippingFee = shippingFee;
+        order.totalAmount = product.price().plus(shippingFee);
+        order.version = 0;
+        return order;
+    }
+
+    // 정적 팩토리 - DB 복원용 (Builder 패턴)
+    // create()와 달리 id/createdAt/version 등 기존 값을 그대로 보존
+    // totalAmount 정합성 검증으로 DB 변조 감지
+    // 사용: Order.restoreBuilder().id(...).buyer(...)...build()
+    @Builder(builderMethodName = "restoreBuilder", buildMethodName = "build")
+    private static Order restoreInternal(
+            OrderId id,
+            Buyer buyer,
+            Seller seller,
+            Product product,
+            OrderType type,
+            OrderStatus status,
+            Money shippingFee,
+            Money totalAmount,
+            Reason cancelReason,
+            Reason returnReason,
+            Reason rejectReason,
+            Instant createdAt,
+            Instant updatedAt,
+            Instant deletedAt,
+            UUID createdBy,
+            UUID updatedBy,
+            UUID deletedBy,
+            Instant confirmedAt,
+            int version
+    ) {
+        validateAmountConsistency(product.price(), shippingFee, totalAmount);
+
+        Order order = new Order();
+        order.id = id;
+        order.buyer = buyer;
+        order.seller = seller;
+        order.product = product;
+        order.type = type;
+        order.status = status;
+        order.shippingFee = shippingFee;
+        order.totalAmount = totalAmount;
+        order.cancelReason = cancelReason;
+        order.returnReason = returnReason;
+        order.rejectReason = rejectReason;
+        order.createdAt = createdAt;
+        order.updatedAt = updatedAt;
+        order.deletedAt = deletedAt;
+        order.createdBy = createdBy;
+        order.updatedBy = updatedBy;
+        order.deletedBy = deletedBy;
+        order.confirmedAt = confirmedAt;
+        order.version = version;
+        return order;
+    }
+
+    // 불변식 검증
+    // 자기 상품 구매 금지 — buyer.id == seller.id 차단
+    private static void validateInvariants(Buyer buyer, Seller seller) {
+        if (Objects.equals(buyer.id(), seller.id())) {
+            throw new SelfPurchaseException();
+        }
+    }
+
+    // 복원 시 totalAmount 정합성 검증 (DB 데이터 변조 감지)
+    private static void validateAmountConsistency(Money productPrice, Money shippingFee, Money totalAmount) {
+        long expected = productPrice.value() + shippingFee.value();
+        if (totalAmount.value() != expected) {
+            throw new AmountMismatchException(expected, totalAmount.value());
+        }
+    }
+
+
+    // 행위 메서드 - 결제 / 배송 / 확정 흐름
+
+    // REQUESTED → PAYMENT_PENDING
+    // 사용자가 결제 시작 액션 (POST /api/orders/{id}/payment-intents)
+    public void requestPayment() {
+        this.status = OrderTransition.apply(this.status, OrderAction.REQUEST_PAYMENT);
+    }
+
+    // PAYMENT_PENDING → PAID
+    // Wallet의 PaymentCompleted 이벤트 수신 시
+    public void markPaid() {
+        this.status = OrderTransition.apply(this.status, OrderAction.MARK_PAID);
+    }
+
+    // PAID → SHIPPING
+    // Delivery의 DeliveryStarted 이벤트 수신 시
+    public void startShipping() {
+        this.status = OrderTransition.apply(this.status, OrderAction.START_SHIPPING);
+    }
+
+    // SHIPPING → DELIVERED
+    // Delivery의 DeliveryCompleted 이벤트 수신 시
+    public void markDelivered() {
+        this.status = OrderTransition.apply(this.status, OrderAction.MARK_DELIVERED);
+    }
+
+    // DELIVERED → CONFIRMED
+    // 사용자가 구매 확정 액션 (POST /api/orders/{id}/confirmations)
+    // confirmedAt에 확정 시각 기록 → PurchaseConfirmedEvent payload에 사용
+    public void confirm(Instant at) {
+        this.status = OrderTransition.apply(this.status, OrderAction.CONFIRM);
+        this.confirmedAt = at;
+    }
+
+    // CONFIRMED → SETTLEMENT_PROCESSING
+    // PurchaseConfirmed 이벤트 발행 직후 자체 전이 (정산 시작)
+    public void startSettlement() {
+        this.status = OrderTransition.apply(this.status, OrderAction.START_SETTLEMENT);
+    }
+
+    // SETTLEMENT_PROCESSING → COMPLETED
+    // Settlement의 SettlementCompleted 이벤트 수신 시
+    public void complete() {
+        this.status = OrderTransition.apply(this.status, OrderAction.COMPLETE);
+    }
+
+
+    // 행위 메서드 — 취소 / 환불
+
+    // 취소 (배송 시작 전 단계만 허용 — REQUESTED/PAYMENT_PENDING → CANCELLED, PAID → REFUND_PROCESSING)
+    // OrderTransition 표가 잘못된 상태 조합을 자동 차단 (CancelNotAllowedException은 application 레이어에서 사전 검증 시 사용)
+    // OrderCancelledEvent를 application/adapter 레이어에서 발행 (Wallet 환불 트리거)
+    public void cancel(Reason reason) {
+        this.status = OrderTransition.apply(this.status, OrderAction.CANCEL);
+        this.cancelReason = reason;
+    }
+
+    // REFUND_PROCESSING → REFUND_COMPLETED
+    // Wallet의 RefundCompleted 이벤트 수신 시
+    public void markRefunded() {
+        this.status = OrderTransition.apply(this.status, OrderAction.MARK_REFUNDED);
+    }
+
+
+    // 행위 메서드 - 반송
+    // 권한 검증(ADMIN 전용 결정)은 application/adapter 레이어 책임 (@PreAuthorize)
+
+    // 반송 요청 - 배송 시작 후만 허용 (SHIPPING/DELIVERED → RETURN_REQUESTED)
+    // 사용자(구매자) 액션. OrderReturnRequestedEvent를 application 레이어에서 발행
+    public void requestReturn(Reason reason) {
+        this.status = OrderTransition.apply(this.status, OrderAction.REQUEST_RETURN);
+        this.returnReason = reason;
+    }
+
+    // 반송 승인 - RETURN_REQUESTED → RETURN_APPROVED
+    // ADMIN 액션 (권한 검증은 어댑터 레이어)
+    public void approveReturn() {
+        this.status = OrderTransition.apply(this.status, OrderAction.APPROVE_RETURN);
+    }
+
+    // 반송 거절 - RETURN_REQUESTED → RETURN_REJECTED
+    // ADMIN 액션. 거절 사유 필수
+    public void rejectReturn(Reason reason) {
+        this.status = OrderTransition.apply(this.status, OrderAction.REJECT_RETURN);
+        this.rejectReason = reason;
+    }
+
+
+    // 소프트 삭제 - deletedAt + deletedBy 기록
+    // 멱등성: 이미 삭제된 엔티티에 재호출돼도 최초 시각/주체 보존
+    public void delete(UUID userId) {
+        if (this.deletedAt != null) {
+            return;
+        }
+        this.deletedAt = Instant.now();
+        this.deletedBy = userId;
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/Order.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/Order.java
@@ -1,6 +1,10 @@
 package com.trustamarket.orderservice.order.domain.model;
 
 import com.trustamarket.orderservice.order.domain.exception.AmountMismatchException;
+import com.trustamarket.orderservice.order.domain.exception.InvalidIdException;
+import com.trustamarket.orderservice.order.domain.exception.InvalidMoneyException;
+import com.trustamarket.orderservice.order.domain.exception.InvalidReasonException;
+import com.trustamarket.orderservice.order.domain.exception.InvalidTimestampException;
 import com.trustamarket.orderservice.order.domain.exception.SelfPurchaseException;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -67,6 +71,7 @@ public class Order {
             OrderType type,
             Money shippingFee
     ) {
+        validateRequiredForCreate(buyer, seller, product, type, shippingFee);
         validateInvariants(buyer, seller);
 
         Order order = new Order();
@@ -108,6 +113,7 @@ public class Order {
             Instant confirmedAt,
             int version
     ) {
+        validateRequiredForRestore(id, buyer, seller, product, type, status, shippingFee, totalAmount);
         validateInvariants(buyer, seller);
         validateAmountConsistency(product.price(), shippingFee, totalAmount);
 
@@ -132,6 +138,34 @@ public class Order {
         order.confirmedAt = confirmedAt;
         order.version = version;
         return order;
+    }
+
+    // 필수 인자 null 가드 — create()
+    // 도메인 self-defending: 호출부 누락 시 NPE 대신 도메인 예외로 명시 실패
+    private static void validateRequiredForCreate(
+            Buyer buyer, Seller seller, Product product, OrderType type, Money shippingFee
+    ) {
+        if (buyer == null) throw new InvalidIdException("buyer");
+        if (seller == null) throw new InvalidIdException("seller");
+        if (product == null) throw new InvalidIdException("product");
+        if (type == null) throw new InvalidIdException("orderType");
+        if (shippingFee == null) throw new InvalidMoneyException("shippingFee");
+    }
+
+    // 필수 인자 null 가드 — restoreInternal()
+    // create() 필수 인자 + 복원 전용(id, status, totalAmount). nullable: reasons, audit, confirmedAt
+    private static void validateRequiredForRestore(
+            OrderId id, Buyer buyer, Seller seller, Product product, OrderType type,
+            OrderStatus status, Money shippingFee, Money totalAmount
+    ) {
+        if (id == null) throw new InvalidIdException("orderId");
+        if (buyer == null) throw new InvalidIdException("buyer");
+        if (seller == null) throw new InvalidIdException("seller");
+        if (product == null) throw new InvalidIdException("product");
+        if (type == null) throw new InvalidIdException("orderType");
+        if (status == null) throw new InvalidIdException("status");
+        if (shippingFee == null) throw new InvalidMoneyException("shippingFee");
+        if (totalAmount == null) throw new InvalidMoneyException("totalAmount");
     }
 
     // 불변식 검증
@@ -187,6 +221,9 @@ public class Order {
     // 사용자가 구매 확정 액션 (POST /api/orders/{id}/confirmations)
     // confirmedAt에 확정 시각 기록 → PurchaseConfirmedEvent payload에 사용
     public void confirm(Instant at) {
+        if (at == null) {
+            throw new InvalidTimestampException("confirmedAt");
+        }
         this.status = OrderTransition.apply(this.status, OrderAction.CONFIRM);
         this.confirmedAt = at;
     }
@@ -210,6 +247,9 @@ public class Order {
     // OrderTransition 표가 잘못된 상태 조합을 자동 차단 (CancelNotAllowedException은 application 레이어에서 사전 검증 시 사용)
     // OrderCancelledEvent를 application/adapter 레이어에서 발행 (Wallet 환불 트리거)
     public void cancel(Reason reason) {
+        if (reason == null) {
+            throw new InvalidReasonException();
+        }
         this.status = OrderTransition.apply(this.status, OrderAction.CANCEL);
         this.cancelReason = reason;
     }
@@ -227,6 +267,9 @@ public class Order {
     // 반송 요청 - 배송 시작 후만 허용 (SHIPPING/DELIVERED → RETURN_REQUESTED)
     // 사용자(구매자) 액션. OrderReturnRequestedEvent를 application 레이어에서 발행
     public void requestReturn(Reason reason) {
+        if (reason == null) {
+            throw new InvalidReasonException();
+        }
         this.status = OrderTransition.apply(this.status, OrderAction.REQUEST_RETURN);
         this.returnReason = reason;
     }
@@ -240,6 +283,9 @@ public class Order {
     // 반송 거절 - RETURN_REQUESTED → RETURN_REJECTED
     // ADMIN 액션. 거절 사유 필수
     public void rejectReturn(Reason reason) {
+        if (reason == null) {
+            throw new InvalidReasonException();
+        }
         this.status = OrderTransition.apply(this.status, OrderAction.REJECT_RETURN);
         this.rejectReason = reason;
     }
@@ -249,6 +295,12 @@ public class Order {
     // 멱등성: 이미 삭제된 엔티티에 재호출돼도 최초 시각/주체 보존
     // 시각은 도메인이 시계에 의존하지 않도록 외부 주입 (헥사고날 원칙 + 테스트 용이성)
     public void delete(UUID userId, Instant at) {
+        if (userId == null) {
+            throw new InvalidIdException("deletedBy");
+        }
+        if (at == null) {
+            throw new InvalidTimestampException("deletedAt");
+        }
         if (this.deletedAt != null) {
             return;
         }

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/Order.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/Order.java
@@ -5,6 +5,7 @@ import com.trustamarket.orderservice.order.domain.exception.InvalidIdException;
 import com.trustamarket.orderservice.order.domain.exception.InvalidMoneyException;
 import com.trustamarket.orderservice.order.domain.exception.InvalidReasonException;
 import com.trustamarket.orderservice.order.domain.exception.InvalidTimestampException;
+import com.trustamarket.orderservice.order.domain.exception.RestoreStateMismatchException;
 import com.trustamarket.orderservice.order.domain.exception.SelfPurchaseException;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -116,6 +117,8 @@ public class Order {
         validateRequiredForRestore(id, buyer, seller, product, type, status, shippingFee, totalAmount);
         validateInvariants(buyer, seller);
         validateAmountConsistency(product.price(), shippingFee, totalAmount);
+        validateStateConsistency(status, cancelReason, returnReason, rejectReason,
+                confirmedAt, deletedAt, deletedBy);
 
         Order order = new Order();
         order.id = id;
@@ -173,6 +176,57 @@ public class Order {
     private static void validateInvariants(Buyer buyer, Seller seller) {
         if (Objects.equals(buyer.id(), seller.id())) {
             throw new SelfPurchaseException();
+        }
+    }
+
+    // 복원 시 상태별 메타데이터 불변식 검증 — 도메인 행위 메서드를 우회하는 유일한 경로(restore)에서 잠금
+    // 정상 도메인 흐름에서는 발생할 수 없는 조합 → DB 변조 감지
+    private static void validateStateConsistency(
+            OrderStatus status,
+            Reason cancelReason,
+            Reason returnReason,
+            Reason rejectReason,
+            Instant confirmedAt,
+            Instant deletedAt,
+            UUID deletedBy
+    ) {
+        // 확정 이후 상태는 confirmedAt 필수
+        if ((status == OrderStatus.CONFIRMED
+                || status == OrderStatus.SETTLEMENT_PROCESSING
+                || status == OrderStatus.COMPLETED)
+                && confirmedAt == null) {
+            throw new RestoreStateMismatchException(
+                    "%s 상태는 confirmedAt이 필수입니다.".formatted(status));
+        }
+
+        // 취소/환불 상태는 cancelReason 필수
+        if ((status == OrderStatus.CANCELLED
+                || status == OrderStatus.REFUND_PROCESSING
+                || status == OrderStatus.REFUND_COMPLETED)
+                && cancelReason == null) {
+            throw new RestoreStateMismatchException(
+                    "%s 상태는 cancelReason이 필수입니다.".formatted(status));
+        }
+
+        // 반송 진입 이후는 returnReason 필수
+        if ((status == OrderStatus.RETURN_REQUESTED
+                || status == OrderStatus.RETURN_APPROVED
+                || status == OrderStatus.RETURN_REJECTED)
+                && returnReason == null) {
+            throw new RestoreStateMismatchException(
+                    "%s 상태는 returnReason이 필수입니다.".formatted(status));
+        }
+
+        // 반송 거절은 rejectReason 추가 필수
+        if (status == OrderStatus.RETURN_REJECTED && rejectReason == null) {
+            throw new RestoreStateMismatchException(
+                    "RETURN_REJECTED 상태는 rejectReason이 필수입니다.");
+        }
+
+        // soft delete 메타데이터는 둘 다 채워지거나 둘 다 비어야 함
+        if ((deletedAt == null) != (deletedBy == null)) {
+            throw new RestoreStateMismatchException(
+                    "deletedAt/deletedBy는 동시에 채워져야 합니다.");
         }
     }
 

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/Order.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/Order.java
@@ -195,8 +195,7 @@ public class Order {
                 || status == OrderStatus.SETTLEMENT_PROCESSING
                 || status == OrderStatus.COMPLETED)
                 && confirmedAt == null) {
-            throw new RestoreStateMismatchException(
-                    "%s 상태는 confirmedAt이 필수입니다.".formatted(status));
+            throw RestoreStateMismatchException.missingConfirmedAt(status);
         }
 
         // 취소/환불 상태는 cancelReason 필수
@@ -204,8 +203,7 @@ public class Order {
                 || status == OrderStatus.REFUND_PROCESSING
                 || status == OrderStatus.REFUND_COMPLETED)
                 && cancelReason == null) {
-            throw new RestoreStateMismatchException(
-                    "%s 상태는 cancelReason이 필수입니다.".formatted(status));
+            throw RestoreStateMismatchException.missingCancelReason(status);
         }
 
         // 반송 진입 이후는 returnReason 필수
@@ -213,20 +211,17 @@ public class Order {
                 || status == OrderStatus.RETURN_APPROVED
                 || status == OrderStatus.RETURN_REJECTED)
                 && returnReason == null) {
-            throw new RestoreStateMismatchException(
-                    "%s 상태는 returnReason이 필수입니다.".formatted(status));
+            throw RestoreStateMismatchException.missingReturnReason(status);
         }
 
         // 반송 거절은 rejectReason 추가 필수
         if (status == OrderStatus.RETURN_REJECTED && rejectReason == null) {
-            throw new RestoreStateMismatchException(
-                    "RETURN_REJECTED 상태는 rejectReason이 필수입니다.");
+            throw RestoreStateMismatchException.missingRejectReason();
         }
 
         // soft delete 메타데이터는 둘 다 채워지거나 둘 다 비어야 함
         if ((deletedAt == null) != (deletedBy == null)) {
-            throw new RestoreStateMismatchException(
-                    "deletedAt/deletedBy는 동시에 채워져야 합니다.");
+            throw RestoreStateMismatchException.inconsistentDeletionMetadata();
         }
     }
 

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/Order.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/Order.java
@@ -108,6 +108,7 @@ public class Order {
             Instant confirmedAt,
             int version
     ) {
+        validateInvariants(buyer, seller);
         validateAmountConsistency(product.price(), shippingFee, totalAmount);
 
         Order order = new Order();
@@ -240,11 +241,12 @@ public class Order {
 
     // 소프트 삭제 - deletedAt + deletedBy 기록
     // 멱등성: 이미 삭제된 엔티티에 재호출돼도 최초 시각/주체 보존
-    public void delete(UUID userId) {
+    // 시각은 도메인이 시계에 의존하지 않도록 외부 주입 (헥사고날 원칙 + 테스트 용이성)
+    public void delete(UUID userId, Instant at) {
         if (this.deletedAt != null) {
             return;
         }
-        this.deletedAt = Instant.now();
+        this.deletedAt = at;
         this.deletedBy = userId;
     }
 

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/Order.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/Order.java
@@ -190,11 +190,8 @@ public class Order {
             Instant deletedAt,
             UUID deletedBy
     ) {
-        // 확정 이후 상태는 confirmedAt 필수
-        if ((status == OrderStatus.CONFIRMED
-                || status == OrderStatus.SETTLEMENT_PROCESSING
-                || status == OrderStatus.COMPLETED)
-                && confirmedAt == null) {
+        // 확정 상태는 confirmedAt 필수
+        if (status == OrderStatus.CONFIRMED && confirmedAt == null) {
             throw RestoreStateMismatchException.missingConfirmedAt(status);
         }
 
@@ -275,18 +272,6 @@ public class Order {
         }
         this.status = OrderTransition.apply(this.status, OrderAction.CONFIRM);
         this.confirmedAt = at;
-    }
-
-    // CONFIRMED → SETTLEMENT_PROCESSING
-    // PurchaseConfirmed 이벤트 발행 직후 자체 전이 (정산 시작)
-    public void startSettlement() {
-        this.status = OrderTransition.apply(this.status, OrderAction.START_SETTLEMENT);
-    }
-
-    // SETTLEMENT_PROCESSING → COMPLETED
-    // Settlement의 SettlementCompleted 이벤트 수신 시
-    public void complete() {
-        this.status = OrderTransition.apply(this.status, OrderAction.COMPLETE);
     }
 
 

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/Order.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/Order.java
@@ -143,8 +143,14 @@ public class Order {
     }
 
     // 복원 시 totalAmount 정합성 검증 (DB 데이터 변조 감지)
+    // Math.addExact로 long 오버플로우 시 변조로 간주 (정상 주문 금액 범위에서 발생 X, 방어적 처리)
     private static void validateAmountConsistency(Money productPrice, Money shippingFee, Money totalAmount) {
-        long expected = productPrice.value() + shippingFee.value();
+        long expected;
+        try {
+            expected = Math.addExact(productPrice.value(), shippingFee.value());
+        } catch (ArithmeticException overflow) {
+            throw new AmountMismatchException(-1, totalAmount.value());
+        }
         if (totalAmount.value() != expected) {
             throw new AmountMismatchException(expected, totalAmount.value());
         }

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderAction.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderAction.java
@@ -12,6 +12,7 @@ public enum OrderAction {
     COMPLETE,             // SETTLEMENT_PROCESSING → COMPLETED
 
     CANCEL,               // (배송 시작 전) → CANCELLED 또는 REFUND_PROCESSING
+    MARK_REFUNDED,        // REFUND_PROCESSING → REFUND_COMPLETED (Wallet RefundCompleted 수신)
 
     REQUEST_RETURN,       // (배송 시작 후) → RETURN_REQUESTED
     APPROVE_RETURN,       // RETURN_REQUESTED → RETURN_APPROVED

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderAction.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderAction.java
@@ -1,0 +1,19 @@
+package com.trustamarket.orderservice.order.domain.model;
+
+// Order 상태 머신의 액션(동작) (OrderTransition이 사용)
+public enum OrderAction {
+
+    REQUEST_PAYMENT,      // REQUESTED → PAYMENT_PENDING
+    MARK_PAID,            // PAYMENT_PENDING → PAID
+    START_SHIPPING,       // PAID → SHIPPING
+    MARK_DELIVERED,       // SHIPPING → DELIVERED
+    CONFIRM,              // DELIVERED → CONFIRMED
+    START_SETTLEMENT,     // CONFIRMED → SETTLEMENT_PROCESSING
+    COMPLETE,             // SETTLEMENT_PROCESSING → COMPLETED
+
+    CANCEL,               // (배송 시작 전) → CANCELLED 또는 REFUND_PROCESSING
+
+    REQUEST_RETURN,       // (배송 시작 후) → RETURN_REQUESTED
+    APPROVE_RETURN,       // RETURN_REQUESTED → RETURN_APPROVED
+    REJECT_RETURN         // RETURN_REQUESTED → RETURN_REJECTED
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderAction.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderAction.java
@@ -7,9 +7,7 @@ public enum OrderAction {
     MARK_PAID,            // PAYMENT_PENDING → PAID
     START_SHIPPING,       // PAID → SHIPPING
     MARK_DELIVERED,       // SHIPPING → DELIVERED
-    CONFIRM,              // DELIVERED → CONFIRMED
-    START_SETTLEMENT,     // CONFIRMED → SETTLEMENT_PROCESSING
-    COMPLETE,             // SETTLEMENT_PROCESSING → COMPLETED
+    CONFIRM,              // DELIVERED → CONFIRMED (거래 종결)
 
     CANCEL,               // (배송 시작 전) → CANCELLED 또는 REFUND_PROCESSING
     MARK_REFUNDED,        // REFUND_PROCESSING → REFUND_COMPLETED (Wallet RefundCompleted 수신)

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderId.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderId.java
@@ -1,0 +1,22 @@
+package com.trustamarket.orderservice.order.domain.model;
+
+import com.trustamarket.orderservice.order.domain.exception.InvalidIdException;
+
+import java.util.UUID;
+
+public record OrderId(UUID value) {
+
+    public OrderId {
+        if (value == null) {
+            throw new InvalidIdException("orderId");
+        }
+    }
+
+    public static OrderId generate() {
+        return new OrderId(UUID.randomUUID());
+    }
+
+    public static OrderId of(UUID value) {
+        return new OrderId(value);
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderReturnId.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderReturnId.java
@@ -1,0 +1,22 @@
+package com.trustamarket.orderservice.order.domain.model;
+
+import com.trustamarket.orderservice.order.domain.exception.InvalidIdException;
+
+import java.util.UUID;
+
+public record OrderReturnId(UUID value) {
+
+    public OrderReturnId {
+        if (value == null) {
+            throw new InvalidIdException("orderReturnId");
+        }
+    }
+
+    public static OrderReturnId generate() {
+        return new OrderReturnId(UUID.randomUUID());
+    }
+
+    public static OrderReturnId of(UUID value) {
+        return new OrderReturnId(value);
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderReturnStatus.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderReturnStatus.java
@@ -1,0 +1,13 @@
+package com.trustamarket.orderservice.order.domain.model;
+
+// 반송 진행 추적 (p_order_return.return_status에 매핑)
+public enum OrderReturnStatus {
+
+    RETURN_REQUESTED,     // 반송 요청
+    RETURN_APPROVED,      // 반송 승인 (ADMIN 결정)
+    RETURN_REJECTED,      // 반송 거절 (ADMIN 결정)
+    RETURN_COLLECTING,    // 구매자 → 센터 반송 배송 중
+    RETURN_RECEIVED,      // 센터 도착
+    RETURN_INSPECTING,    // 재검수 중
+    RETURN_COMPLETED      // 반송 완료 (이후 환불 흐름)
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderStatus.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderStatus.java
@@ -7,9 +7,7 @@ public enum OrderStatus {
     PAID,                  // 결제 완료 (Wallet holding 보관)
     SHIPPING,              // 배송 중
     DELIVERED,             // 배송 완료
-    CONFIRMED,             // 구매 확정 (Settlement에 정산 트리거)
-    SETTLEMENT_PROCESSING, // 정산 처리 중 (Settlement → Wallet transfer 진행)
-    COMPLETED,             // 거래 종결 (정산 완료)
+    CONFIRMED,             // 구매 확정 — 거래 종결 (정산 흐름은 추후 별도 PR에서 도입)
     CANCELLED,             // 결제 전 취소
     REFUND_PROCESSING,     // 결제 후 취소, 환불 처리 중
     REFUND_COMPLETED,      // 환불 완료
@@ -18,9 +16,8 @@ public enum OrderStatus {
     RETURN_REJECTED;       // 반송 거절
 
     // 종결 상태 — 더 이상 OrderTransition 표에 out-going 전이 없음
-    // RETURN_APPROVED 이후는 OrderReturnStatus 영역으로 이관 (Order 레벨에서는 종결)
     public boolean isTerminal() {
-        return this == COMPLETED
+        return this == CONFIRMED
                 || this == CANCELLED
                 || this == REFUND_COMPLETED
                 || this == RETURN_REJECTED

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderStatus.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderStatus.java
@@ -1,0 +1,27 @@
+package com.trustamarket.orderservice.order.domain.model;
+
+public enum OrderStatus {
+
+    REQUESTED,             // 주문 생성됨
+    PAYMENT_PENDING,       // 결제 시작 (Wallet 차감 대기)
+    PAID,                  // 결제 완료 (Wallet holding 보관)
+    SHIPPING,              // 배송 중
+    DELIVERED,             // 배송 완료
+    CONFIRMED,             // 구매 확정 (Settlement에 정산 트리거)
+    SETTLEMENT_PROCESSING, // 정산 처리 중 (Settlement → Wallet transfer 진행)
+    COMPLETED,             // 거래 종결 (정산 완료)
+    CANCELLED,             // 결제 전 취소
+    REFUND_PROCESSING,     // 결제 후 취소, 환불 처리 중
+    REFUND_COMPLETED,      // 환불 완료
+    RETURN_REQUESTED,      // 반송 요청 (배송 시작 후만 가능)
+    RETURN_APPROVED,       // 반송 승인 (이후 OrderReturnStatus가 추적)
+    RETURN_REJECTED;       // 반송 거절
+
+    // 종결 상태 — 더 이상 전이 불가
+    public boolean isTerminal() {
+        return this == COMPLETED
+                || this == CANCELLED
+                || this == REFUND_COMPLETED
+                || this == RETURN_REJECTED;
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderStatus.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderStatus.java
@@ -17,11 +17,13 @@ public enum OrderStatus {
     RETURN_APPROVED,       // 반송 승인 (이후 OrderReturnStatus가 추적)
     RETURN_REJECTED;       // 반송 거절
 
-    // 종결 상태 — 더 이상 전이 불가
+    // 종결 상태 — 더 이상 OrderTransition 표에 out-going 전이 없음
+    // RETURN_APPROVED 이후는 OrderReturnStatus 영역으로 이관 (Order 레벨에서는 종결)
     public boolean isTerminal() {
         return this == COMPLETED
                 || this == CANCELLED
                 || this == REFUND_COMPLETED
-                || this == RETURN_REJECTED;
+                || this == RETURN_REJECTED
+                || this == RETURN_APPROVED;
     }
 }

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderTransition.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderTransition.java
@@ -1,0 +1,81 @@
+package com.trustamarket.orderservice.order.domain.model;
+
+import com.trustamarket.orderservice.order.domain.exception.InvalidStatusTransitionException;
+
+import java.util.Map;
+
+import static com.trustamarket.orderservice.order.domain.model.OrderAction.APPROVE_RETURN;
+import static com.trustamarket.orderservice.order.domain.model.OrderAction.CANCEL;
+import static com.trustamarket.orderservice.order.domain.model.OrderAction.COMPLETE;
+import static com.trustamarket.orderservice.order.domain.model.OrderAction.CONFIRM;
+import static com.trustamarket.orderservice.order.domain.model.OrderAction.MARK_DELIVERED;
+import static com.trustamarket.orderservice.order.domain.model.OrderAction.MARK_PAID;
+import static com.trustamarket.orderservice.order.domain.model.OrderAction.MARK_REFUNDED;
+import static com.trustamarket.orderservice.order.domain.model.OrderAction.REJECT_RETURN;
+import static com.trustamarket.orderservice.order.domain.model.OrderAction.REQUEST_PAYMENT;
+import static com.trustamarket.orderservice.order.domain.model.OrderAction.REQUEST_RETURN;
+import static com.trustamarket.orderservice.order.domain.model.OrderAction.START_SETTLEMENT;
+import static com.trustamarket.orderservice.order.domain.model.OrderAction.START_SHIPPING;
+import static com.trustamarket.orderservice.order.domain.model.OrderStatus.CANCELLED;
+import static com.trustamarket.orderservice.order.domain.model.OrderStatus.COMPLETED;
+import static com.trustamarket.orderservice.order.domain.model.OrderStatus.CONFIRMED;
+import static com.trustamarket.orderservice.order.domain.model.OrderStatus.DELIVERED;
+import static com.trustamarket.orderservice.order.domain.model.OrderStatus.PAID;
+import static com.trustamarket.orderservice.order.domain.model.OrderStatus.PAYMENT_PENDING;
+import static com.trustamarket.orderservice.order.domain.model.OrderStatus.REFUND_COMPLETED;
+import static com.trustamarket.orderservice.order.domain.model.OrderStatus.REFUND_PROCESSING;
+import static com.trustamarket.orderservice.order.domain.model.OrderStatus.REQUESTED;
+import static com.trustamarket.orderservice.order.domain.model.OrderStatus.RETURN_APPROVED;
+import static com.trustamarket.orderservice.order.domain.model.OrderStatus.RETURN_REJECTED;
+import static com.trustamarket.orderservice.order.domain.model.OrderStatus.RETURN_REQUESTED;
+import static com.trustamarket.orderservice.order.domain.model.OrderStatus.SETTLEMENT_PROCESSING;
+import static com.trustamarket.orderservice.order.domain.model.OrderStatus.SHIPPING;
+
+// Order 상태 머신 — 표 기반
+// 모든 상태 전이는 (현재 상태 + 액션) -> 다음 상태 형태로 TABLE에 정의
+// 표에 없는 조합은 InvalidStatusTransitionException throw
+//
+// 시나리오 매트릭스가 코드에 1:1 매칭되어 한 곳에서 전이 규칙 관리.
+public final class OrderTransition {
+
+    public record Key(OrderStatus from, OrderAction action) {}
+
+    private static final Map<Key, OrderStatus> TABLE = Map.ofEntries(
+            // Happy path
+            // Map.entry((현재상태+액션) -> 다음 상태)
+            Map.entry(new Key(REQUESTED,             REQUEST_PAYMENT),  PAYMENT_PENDING),
+            Map.entry(new Key(PAYMENT_PENDING,       MARK_PAID),        PAID),
+            Map.entry(new Key(PAID,                  START_SHIPPING),   SHIPPING),
+            Map.entry(new Key(SHIPPING,              MARK_DELIVERED),   DELIVERED),
+            Map.entry(new Key(DELIVERED,             CONFIRM),          CONFIRMED),
+            Map.entry(new Key(CONFIRMED,             START_SETTLEMENT), SETTLEMENT_PROCESSING),
+            Map.entry(new Key(SETTLEMENT_PROCESSING, COMPLETE),         COMPLETED),
+
+            // 취소 분기 (배송 시작 전까지만)
+            Map.entry(new Key(REQUESTED,             CANCEL),           CANCELLED),
+            Map.entry(new Key(PAYMENT_PENDING,       CANCEL),           CANCELLED),
+            Map.entry(new Key(PAID,                  CANCEL),           REFUND_PROCESSING),
+
+            // 환불 완료 (Wallet RefundCompleted 수신)
+            Map.entry(new Key(REFUND_PROCESSING,     MARK_REFUNDED),    REFUND_COMPLETED),
+
+            // 반송 분기 (배송 시작 후만)
+            Map.entry(new Key(SHIPPING,              REQUEST_RETURN),   RETURN_REQUESTED),
+            Map.entry(new Key(DELIVERED,             REQUEST_RETURN),   RETURN_REQUESTED),
+            Map.entry(new Key(RETURN_REQUESTED,      APPROVE_RETURN),   RETURN_APPROVED),
+            Map.entry(new Key(RETURN_REQUESTED,      REJECT_RETURN),    RETURN_REJECTED)
+    );
+
+    // 현재 상태에 액션을 적용해 다음 상태 반환 (조합이 맞나 확인)
+    // 허용되지 않는 (상태, 액션) 조합이면 InvalidStatusTransitionException throw
+    public static OrderStatus apply(OrderStatus current, OrderAction action) {
+        OrderStatus next = TABLE.get(new Key(current, action));
+        if (next == null) {
+            throw new InvalidStatusTransitionException(current, action);
+        }
+        return next;
+    }
+
+    // 정적 유틸 — 인스턴스화 차단
+    private OrderTransition() {}
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderTransition.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderTransition.java
@@ -6,7 +6,6 @@ import java.util.Map;
 
 import static com.trustamarket.orderservice.order.domain.model.OrderAction.APPROVE_RETURN;
 import static com.trustamarket.orderservice.order.domain.model.OrderAction.CANCEL;
-import static com.trustamarket.orderservice.order.domain.model.OrderAction.COMPLETE;
 import static com.trustamarket.orderservice.order.domain.model.OrderAction.CONFIRM;
 import static com.trustamarket.orderservice.order.domain.model.OrderAction.MARK_DELIVERED;
 import static com.trustamarket.orderservice.order.domain.model.OrderAction.MARK_PAID;
@@ -14,10 +13,8 @@ import static com.trustamarket.orderservice.order.domain.model.OrderAction.MARK_
 import static com.trustamarket.orderservice.order.domain.model.OrderAction.REJECT_RETURN;
 import static com.trustamarket.orderservice.order.domain.model.OrderAction.REQUEST_PAYMENT;
 import static com.trustamarket.orderservice.order.domain.model.OrderAction.REQUEST_RETURN;
-import static com.trustamarket.orderservice.order.domain.model.OrderAction.START_SETTLEMENT;
 import static com.trustamarket.orderservice.order.domain.model.OrderAction.START_SHIPPING;
 import static com.trustamarket.orderservice.order.domain.model.OrderStatus.CANCELLED;
-import static com.trustamarket.orderservice.order.domain.model.OrderStatus.COMPLETED;
 import static com.trustamarket.orderservice.order.domain.model.OrderStatus.CONFIRMED;
 import static com.trustamarket.orderservice.order.domain.model.OrderStatus.DELIVERED;
 import static com.trustamarket.orderservice.order.domain.model.OrderStatus.PAID;
@@ -28,7 +25,6 @@ import static com.trustamarket.orderservice.order.domain.model.OrderStatus.REQUE
 import static com.trustamarket.orderservice.order.domain.model.OrderStatus.RETURN_APPROVED;
 import static com.trustamarket.orderservice.order.domain.model.OrderStatus.RETURN_REJECTED;
 import static com.trustamarket.orderservice.order.domain.model.OrderStatus.RETURN_REQUESTED;
-import static com.trustamarket.orderservice.order.domain.model.OrderStatus.SETTLEMENT_PROCESSING;
 import static com.trustamarket.orderservice.order.domain.model.OrderStatus.SHIPPING;
 
 // Order 상태 머신 — 표 기반
@@ -41,15 +37,13 @@ public final class OrderTransition {
     public record Key(OrderStatus from, OrderAction action) {}
 
     private static final Map<Key, OrderStatus> TABLE = Map.ofEntries(
-            // Happy path
+            // Happy path — REQUESTED부터 CONFIRMED까지. CONFIRMED가 거래 종결
             // Map.entry((현재상태+액션) -> 다음 상태)
             Map.entry(new Key(REQUESTED,             REQUEST_PAYMENT),  PAYMENT_PENDING),
             Map.entry(new Key(PAYMENT_PENDING,       MARK_PAID),        PAID),
             Map.entry(new Key(PAID,                  START_SHIPPING),   SHIPPING),
             Map.entry(new Key(SHIPPING,              MARK_DELIVERED),   DELIVERED),
             Map.entry(new Key(DELIVERED,             CONFIRM),          CONFIRMED),
-            Map.entry(new Key(CONFIRMED,             START_SETTLEMENT), SETTLEMENT_PROCESSING),
-            Map.entry(new Key(SETTLEMENT_PROCESSING, COMPLETE),         COMPLETED),
 
             // 취소 분기 (배송 시작 전까지만)
             Map.entry(new Key(REQUESTED,             CANCEL),           CANCELLED),

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderType.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderType.java
@@ -1,0 +1,6 @@
+package com.trustamarket.orderservice.order.domain.model;
+
+public enum OrderType {
+    LOW,    // 저가 상품 (검수 없음)
+    HIGH    // 고가 상품 (검수 후 ON_SALE 도달한 상품)
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/Product.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/Product.java
@@ -1,6 +1,7 @@
 package com.trustamarket.orderservice.order.domain.model;
 
 import com.trustamarket.orderservice.order.domain.exception.InvalidIdException;
+import com.trustamarket.orderservice.order.domain.exception.InvalidMoneyException;
 import com.trustamarket.orderservice.order.domain.exception.InvalidNameException;
 
 import java.util.UUID;
@@ -18,7 +19,7 @@ public record Product(UUID id, String name, Money price) {
             throw new InvalidNameException("productName");
         }
         if (price == null) {
-            throw new InvalidIdException("productPrice");
+            throw new InvalidMoneyException("productPrice");
         }
     }
 

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/Product.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/Product.java
@@ -1,0 +1,28 @@
+package com.trustamarket.orderservice.order.domain.model;
+
+import com.trustamarket.orderservice.order.domain.exception.InvalidIdException;
+import com.trustamarket.orderservice.order.domain.exception.InvalidNameException;
+
+import java.util.UUID;
+
+// 상품 스냅샷 — 주문 시점의 id + name + price를 보존
+// Product 도메인의 이름/가격이 추후 변경되어도 Order의 product 정보는 변하지 않음
+// 정산은 이 시점 가격(price) 기준으로 이루어짐
+public record Product(UUID id, String name, Money price) {
+
+    public Product {
+        if (id == null) {
+            throw new InvalidIdException("productId");
+        }
+        if (name == null || name.isBlank()) {
+            throw new InvalidNameException("productName");
+        }
+        if (price == null) {
+            throw new InvalidIdException("productPrice");
+        }
+    }
+
+    public static Product of(UUID id, String name, Money price) {
+        return new Product(id, name, price);
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/Reason.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/Reason.java
@@ -1,0 +1,23 @@
+package com.trustamarket.orderservice.order.domain.model;
+
+import com.trustamarket.orderservice.order.domain.exception.InvalidReasonException;
+
+// 사유 VO — 취소/반송/거절 사유 보관
+// 비어있을 수 없고 최대 200자
+public record Reason(String value) {
+
+    public static final int MAX_LENGTH = 200;
+
+    public Reason {
+        if (value == null || value.isBlank()) {
+            throw new InvalidReasonException();
+        }
+        if (value.length() > MAX_LENGTH) {
+            throw new InvalidReasonException();
+        }
+    }
+
+    public static Reason of(String value) {
+        return new Reason(value);
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/Seller.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/Seller.java
@@ -1,0 +1,24 @@
+package com.trustamarket.orderservice.order.domain.model;
+
+import com.trustamarket.orderservice.order.domain.exception.InvalidIdException;
+import com.trustamarket.orderservice.order.domain.exception.InvalidNameException;
+
+import java.util.UUID;
+
+// 판매자 snapshot — 주문 시점의 id + name을 보존
+// User 도메인의 이름이 추후 변경되어도 Order의 seller 정보는 변하지 않음 (audit/무결성)
+public record Seller(UUID id, String name) {
+
+    public Seller {
+        if (id == null) {
+            throw new InvalidIdException("sellerId");
+        }
+        if (name == null || name.isBlank()) {
+            throw new InvalidNameException("sellerName");
+        }
+    }
+
+    public static Seller of(UUID id, String name) {
+        return new Seller(id, name);
+    }
+}

--- a/src/test/java/com/trustamarket/orderservice/order/domain/model/MoneyTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/domain/model/MoneyTest.java
@@ -83,4 +83,20 @@ class MoneyTest {
         assertThatThrownBy(() -> Money.of(1_000).equalsAmount(null))
                 .isInstanceOf(InvalidMoneyException.class);
     }
+
+    @Test
+    @DisplayName("plus 결과가 long 범위 초과 시 InvalidMoneyException (음수 wrap-around 차단)")
+    void plusOverflow() {
+        Money max = Money.of(Long.MAX_VALUE);
+        assertThatThrownBy(() -> max.plus(Money.of(1)))
+                .isInstanceOf(InvalidMoneyException.class);
+    }
+
+    @Test
+    @DisplayName("minus 결과가 음수면 InvalidMoneyException (Math.subtractExact는 long underflow도 방어)")
+    void minusUnderflow() {
+        Money zero = Money.ZERO;
+        assertThatThrownBy(() -> zero.minus(Money.of(1)))
+                .isInstanceOf(InvalidMoneyException.class);
+    }
 }

--- a/src/test/java/com/trustamarket/orderservice/order/domain/model/MoneyTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/domain/model/MoneyTest.java
@@ -62,4 +62,25 @@ class MoneyTest {
         assertThat(Money.of(1_000).equalsAmount(Money.of(1_000))).isTrue();
         assertThat(Money.of(1_000).equalsAmount(Money.of(2_000))).isFalse();
     }
+
+    @Test
+    @DisplayName("plus에 null 인자 → InvalidMoneyException")
+    void plusNull() {
+        assertThatThrownBy(() -> Money.of(1_000).plus(null))
+                .isInstanceOf(InvalidMoneyException.class);
+    }
+
+    @Test
+    @DisplayName("minus에 null 인자 → InvalidMoneyException")
+    void minusNull() {
+        assertThatThrownBy(() -> Money.of(1_000).minus(null))
+                .isInstanceOf(InvalidMoneyException.class);
+    }
+
+    @Test
+    @DisplayName("equalsAmount에 null 인자 → InvalidMoneyException")
+    void equalsAmountNull() {
+        assertThatThrownBy(() -> Money.of(1_000).equalsAmount(null))
+                .isInstanceOf(InvalidMoneyException.class);
+    }
 }

--- a/src/test/java/com/trustamarket/orderservice/order/domain/model/MoneyTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/domain/model/MoneyTest.java
@@ -1,0 +1,65 @@
+package com.trustamarket.orderservice.order.domain.model;
+
+import com.trustamarket.orderservice.order.domain.exception.InvalidMoneyException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MoneyTest {
+
+    @Test
+    @DisplayName("of()로 생성한다")
+    void create() {
+        Money money = Money.of(10_000);
+        assertThat(money.value()).isEqualTo(10_000);
+    }
+
+    @Test
+    @DisplayName("ZERO 상수는 0원이다")
+    void zero() {
+        assertThat(Money.ZERO.value()).isZero();
+    }
+
+    @Test
+    @DisplayName("0원도 허용한다")
+    void allowZero() {
+        assertThat(Money.of(0).value()).isZero();
+    }
+
+    @Test
+    @DisplayName("음수는 거부한다")
+    void rejectNegative() {
+        assertThatThrownBy(() -> Money.of(-1))
+                .isInstanceOf(InvalidMoneyException.class);
+    }
+
+    @Test
+    @DisplayName("plus는 두 금액을 더한다")
+    void plus() {
+        Money result = Money.of(10_000).plus(Money.of(3_000));
+        assertThat(result.value()).isEqualTo(13_000);
+    }
+
+    @Test
+    @DisplayName("minus는 두 금액을 뺀다")
+    void minus() {
+        Money result = Money.of(10_000).minus(Money.of(3_000));
+        assertThat(result.value()).isEqualTo(7_000);
+    }
+
+    @Test
+    @DisplayName("minus 결과가 음수면 거부한다")
+    void minusNegative() {
+        assertThatThrownBy(() -> Money.of(1_000).minus(Money.of(2_000)))
+                .isInstanceOf(InvalidMoneyException.class);
+    }
+
+    @Test
+    @DisplayName("equalsAmount는 값이 같을 때 true")
+    void equalsAmount() {
+        assertThat(Money.of(1_000).equalsAmount(Money.of(1_000))).isTrue();
+        assertThat(Money.of(1_000).equalsAmount(Money.of(2_000))).isFalse();
+    }
+}

--- a/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderStatusTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderStatusTest.java
@@ -1,0 +1,28 @@
+package com.trustamarket.orderservice.order.domain.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OrderStatusTest {
+
+    // 종결 상태: OrderTransition 표에 out-going 전이가 없는 상태
+    private static final Set<OrderStatus> TERMINAL = Set.of(
+            OrderStatus.COMPLETED,
+            OrderStatus.CANCELLED,
+            OrderStatus.REFUND_COMPLETED,
+            OrderStatus.RETURN_REJECTED,
+            OrderStatus.RETURN_APPROVED
+    );
+
+    @ParameterizedTest
+    @EnumSource(OrderStatus.class)
+    @DisplayName("isTerminal()은 표 기반 종결 상태와 일치한다")
+    void isTerminal(OrderStatus status) {
+        assertThat(status.isTerminal()).isEqualTo(TERMINAL.contains(status));
+    }
+}

--- a/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderStatusTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderStatusTest.java
@@ -12,7 +12,7 @@ class OrderStatusTest {
 
     // 종결 상태: OrderTransition 표에 out-going 전이가 없는 상태
     private static final Set<OrderStatus> TERMINAL = Set.of(
-            OrderStatus.COMPLETED,
+            OrderStatus.CONFIRMED,
             OrderStatus.CANCELLED,
             OrderStatus.REFUND_COMPLETED,
             OrderStatus.RETURN_REJECTED,

--- a/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderTest.java
@@ -6,6 +6,7 @@ import com.trustamarket.orderservice.order.domain.exception.InvalidMoneyExceptio
 import com.trustamarket.orderservice.order.domain.exception.InvalidReasonException;
 import com.trustamarket.orderservice.order.domain.exception.InvalidStatusTransitionException;
 import com.trustamarket.orderservice.order.domain.exception.InvalidTimestampException;
+import com.trustamarket.orderservice.order.domain.exception.RestoreStateMismatchException;
 import com.trustamarket.orderservice.order.domain.exception.SelfPurchaseException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -393,6 +394,93 @@ class OrderTest {
                     .version(0)
                     .build())
                     .isInstanceOf(SelfPurchaseException.class);
+        }
+
+        // 상태별 메타데이터 불변식 검증 (DB 변조 감지) — 도메인 행위 메서드를 우회하는 유일한 경로
+
+        private static Order.OrderBuilder baseBuilder(OrderStatus status) {
+            return Order.restoreBuilder()
+                    .id(OrderId.generate())
+                    .buyer(buyer())
+                    .seller(seller())
+                    .product(product())
+                    .type(OrderType.LOW)
+                    .status(status)
+                    .shippingFee(SHIPPING)
+                    .totalAmount(PRICE.plus(SHIPPING))
+                    .version(0);
+        }
+
+        @Test
+        @DisplayName("CONFIRMED인데 confirmedAt == null이면 RestoreStateMismatch")
+        void confirmedWithoutConfirmedAt() {
+            assertThatThrownBy(() -> baseBuilder(OrderStatus.CONFIRMED).build())
+                    .isInstanceOf(RestoreStateMismatchException.class);
+        }
+
+        @Test
+        @DisplayName("SETTLEMENT_PROCESSING/COMPLETED도 confirmedAt 필수")
+        void settlementCompletedWithoutConfirmedAt() {
+            assertThatThrownBy(() -> baseBuilder(OrderStatus.SETTLEMENT_PROCESSING).build())
+                    .isInstanceOf(RestoreStateMismatchException.class);
+            assertThatThrownBy(() -> baseBuilder(OrderStatus.COMPLETED).build())
+                    .isInstanceOf(RestoreStateMismatchException.class);
+        }
+
+        @Test
+        @DisplayName("CANCELLED/REFUND_PROCESSING/REFUND_COMPLETED는 cancelReason 필수")
+        void cancelledWithoutCancelReason() {
+            assertThatThrownBy(() -> baseBuilder(OrderStatus.CANCELLED).build())
+                    .isInstanceOf(RestoreStateMismatchException.class);
+            assertThatThrownBy(() -> baseBuilder(OrderStatus.REFUND_PROCESSING).build())
+                    .isInstanceOf(RestoreStateMismatchException.class);
+            assertThatThrownBy(() -> baseBuilder(OrderStatus.REFUND_COMPLETED).build())
+                    .isInstanceOf(RestoreStateMismatchException.class);
+        }
+
+        @Test
+        @DisplayName("RETURN_REQUESTED/APPROVED/REJECTED는 returnReason 필수")
+        void returnWithoutReturnReason() {
+            assertThatThrownBy(() -> baseBuilder(OrderStatus.RETURN_REQUESTED).build())
+                    .isInstanceOf(RestoreStateMismatchException.class);
+            assertThatThrownBy(() -> baseBuilder(OrderStatus.RETURN_APPROVED).build())
+                    .isInstanceOf(RestoreStateMismatchException.class);
+        }
+
+        @Test
+        @DisplayName("RETURN_REJECTED는 rejectReason 추가 필수")
+        void rejectedWithoutRejectReason() {
+            assertThatThrownBy(() -> baseBuilder(OrderStatus.RETURN_REJECTED)
+                    .returnReason(Reason.of("불량"))
+                    .build())
+                    .isInstanceOf(RestoreStateMismatchException.class);
+        }
+
+        @Test
+        @DisplayName("deletedAt만 채워지고 deletedBy가 null이면 RestoreStateMismatch")
+        void halfDeletedAt() {
+            assertThatThrownBy(() -> baseBuilder(OrderStatus.REQUESTED)
+                    .deletedAt(Instant.parse("2026-04-30T12:00:00Z"))
+                    .build())
+                    .isInstanceOf(RestoreStateMismatchException.class);
+        }
+
+        @Test
+        @DisplayName("deletedBy만 채워지고 deletedAt이 null이면 RestoreStateMismatch")
+        void halfDeletedBy() {
+            assertThatThrownBy(() -> baseBuilder(OrderStatus.REQUESTED)
+                    .deletedBy(UUID.randomUUID())
+                    .build())
+                    .isInstanceOf(RestoreStateMismatchException.class);
+        }
+
+        @Test
+        @DisplayName("CONFIRMED + confirmedAt 정상 조합은 통과")
+        void confirmedWithConfirmedAt() {
+            Order order = baseBuilder(OrderStatus.CONFIRMED)
+                    .confirmedAt(Instant.parse("2026-04-30T12:00:00Z"))
+                    .build();
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.CONFIRMED);
         }
     }
 }

--- a/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderTest.java
@@ -1,0 +1,295 @@
+package com.trustamarket.orderservice.order.domain.model;
+
+import com.trustamarket.orderservice.order.domain.exception.AmountMismatchException;
+import com.trustamarket.orderservice.order.domain.exception.InvalidStatusTransitionException;
+import com.trustamarket.orderservice.order.domain.exception.SelfPurchaseException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OrderTest {
+
+    private static final Money PRICE = Money.of(100_000);
+    private static final Money SHIPPING = Money.of(3_000);
+
+    private static Buyer buyer() {
+        return Buyer.of(UUID.randomUUID(), "구매자");
+    }
+
+    private static Seller seller() {
+        return Seller.of(UUID.randomUUID(), "판매자");
+    }
+
+    private static Product product() {
+        return Product.of(UUID.randomUUID(), "상품", PRICE);
+    }
+
+    private static Order newOrder() {
+        return Order.create(buyer(), seller(), product(), OrderType.LOW, SHIPPING);
+    }
+
+    @Nested
+    class Create {
+        @Test
+        @DisplayName("create()는 REQUESTED 상태로 시작하고 totalAmount는 자동 계산")
+        void create() {
+            Order order = newOrder();
+
+            assertThat(order.getId()).isNotNull();
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.REQUESTED);
+            assertThat(order.getTotalAmount().value()).isEqualTo(PRICE.value() + SHIPPING.value());
+            assertThat(order.getVersion()).isZero();
+        }
+
+        @Test
+        @DisplayName("buyer.id == seller.id 면 SelfPurchaseException")
+        void rejectSelfPurchase() {
+            UUID sameId = UUID.randomUUID();
+            Buyer buyer = Buyer.of(sameId, "본인");
+            Seller seller = Seller.of(sameId, "본인");
+
+            assertThatThrownBy(() -> Order.create(buyer, seller, product(), OrderType.LOW, SHIPPING))
+                    .isInstanceOf(SelfPurchaseException.class);
+        }
+    }
+
+    @Nested
+    class HappyPath {
+        @Test
+        @DisplayName("REQUESTED → COMPLETED 전체 흐름")
+        void fullFlow() {
+            Order order = newOrder();
+
+            order.requestPayment();
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.PAYMENT_PENDING);
+
+            order.markPaid();
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.PAID);
+
+            order.startShipping();
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.SHIPPING);
+
+            order.markDelivered();
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.DELIVERED);
+
+            Instant confirmedAt = Instant.parse("2026-04-30T12:00:00Z");
+            order.confirm(confirmedAt);
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.CONFIRMED);
+            assertThat(order.getConfirmedAt()).isEqualTo(confirmedAt);
+
+            order.startSettlement();
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.SETTLEMENT_PROCESSING);
+
+            order.complete();
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.COMPLETED);
+        }
+
+        @Test
+        @DisplayName("REQUESTED 상태에서 markPaid()는 차단")
+        void invalidJump() {
+            Order order = newOrder();
+            assertThatThrownBy(order::markPaid)
+                    .isInstanceOf(InvalidStatusTransitionException.class);
+        }
+    }
+
+    @Nested
+    class Cancel {
+        @Test
+        @DisplayName("REQUESTED에서 cancel은 CANCELLED + reason 채워짐")
+        void cancelBeforePayment() {
+            Order order = newOrder();
+            Reason reason = Reason.of("변심");
+
+            order.cancel(reason);
+
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+            assertThat(order.getCancelReason()).isEqualTo(reason);
+        }
+
+        @Test
+        @DisplayName("PAID에서 cancel은 REFUND_PROCESSING")
+        void cancelAfterPayment() {
+            Order order = newOrder();
+            order.requestPayment();
+            order.markPaid();
+
+            order.cancel(Reason.of("환불"));
+
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.REFUND_PROCESSING);
+        }
+
+        @Test
+        @DisplayName("REFUND_PROCESSING에서 markRefunded는 REFUND_COMPLETED")
+        void markRefunded() {
+            Order order = newOrder();
+            order.requestPayment();
+            order.markPaid();
+            order.cancel(Reason.of("환불"));
+
+            order.markRefunded();
+
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.REFUND_COMPLETED);
+        }
+
+        @Test
+        @DisplayName("SHIPPING에서 cancel 차단")
+        void cancelAfterShipping() {
+            Order order = newOrder();
+            order.requestPayment();
+            order.markPaid();
+            order.startShipping();
+
+            assertThatThrownBy(() -> order.cancel(Reason.of("늦음")))
+                    .isInstanceOf(InvalidStatusTransitionException.class);
+        }
+    }
+
+    @Nested
+    class Return {
+        @Test
+        @DisplayName("SHIPPING에서 requestReturn은 RETURN_REQUESTED + reason 채워짐")
+        void requestReturnFromShipping() {
+            Order order = newOrder();
+            order.requestPayment();
+            order.markPaid();
+            order.startShipping();
+
+            Reason reason = Reason.of("불량품");
+            order.requestReturn(reason);
+
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.RETURN_REQUESTED);
+            assertThat(order.getReturnReason()).isEqualTo(reason);
+        }
+
+        @Test
+        @DisplayName("approveReturn은 RETURN_APPROVED")
+        void approveReturn() {
+            Order order = newOrder();
+            order.requestPayment();
+            order.markPaid();
+            order.startShipping();
+            order.requestReturn(Reason.of("불량"));
+
+            order.approveReturn();
+
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.RETURN_APPROVED);
+        }
+
+        @Test
+        @DisplayName("rejectReturn은 RETURN_REJECTED + rejectReason 채워짐")
+        void rejectReturn() {
+            Order order = newOrder();
+            order.requestPayment();
+            order.markPaid();
+            order.startShipping();
+            order.requestReturn(Reason.of("불량"));
+
+            Reason rejectReason = Reason.of("증빙 부족");
+            order.rejectReturn(rejectReason);
+
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.RETURN_REJECTED);
+            assertThat(order.getRejectReason()).isEqualTo(rejectReason);
+        }
+
+        @Test
+        @DisplayName("PAID에서 requestReturn 차단 (배송 시작 전)")
+        void rejectReturnBeforeShipping() {
+            Order order = newOrder();
+            order.requestPayment();
+            order.markPaid();
+
+            assertThatThrownBy(() -> order.requestReturn(Reason.of("불량")))
+                    .isInstanceOf(InvalidStatusTransitionException.class);
+        }
+    }
+
+    @Nested
+    class SoftDelete {
+        @Test
+        @DisplayName("delete()는 deletedAt + deletedBy 기록")
+        void delete() {
+            Order order = newOrder();
+            UUID userId = UUID.randomUUID();
+
+            order.delete(userId);
+
+            assertThat(order.isDeleted()).isTrue();
+            assertThat(order.getDeletedAt()).isNotNull();
+            assertThat(order.getDeletedBy()).isEqualTo(userId);
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 엔티티에 재호출해도 최초 시각/주체 보존 (멱등성)")
+        void deleteIdempotent() throws InterruptedException {
+            Order order = newOrder();
+            UUID firstUser = UUID.randomUUID();
+            order.delete(firstUser);
+            Instant firstAt = order.getDeletedAt();
+
+            Thread.sleep(5);
+            order.delete(UUID.randomUUID());
+
+            assertThat(order.getDeletedAt()).isEqualTo(firstAt);
+            assertThat(order.getDeletedBy()).isEqualTo(firstUser);
+        }
+    }
+
+    @Nested
+    class Restore {
+        @Test
+        @DisplayName("restoreBuilder는 기존 값을 그대로 보존")
+        void restore() {
+            OrderId id = OrderId.generate();
+            Buyer buyer = buyer();
+            Seller seller = seller();
+            Product product = product();
+            Money totalAmount = PRICE.plus(SHIPPING);
+            Instant now = Instant.parse("2026-04-30T12:00:00Z");
+
+            Order order = Order.restoreBuilder()
+                    .id(id)
+                    .buyer(buyer)
+                    .seller(seller)
+                    .product(product)
+                    .type(OrderType.HIGH)
+                    .status(OrderStatus.PAID)
+                    .shippingFee(SHIPPING)
+                    .totalAmount(totalAmount)
+                    .createdAt(now)
+                    .updatedAt(now)
+                    .createdBy(buyer.id())
+                    .updatedBy(buyer.id())
+                    .version(3)
+                    .build();
+
+            assertThat(order.getId()).isEqualTo(id);
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.PAID);
+            assertThat(order.getVersion()).isEqualTo(3);
+            assertThat(order.getCreatedAt()).isEqualTo(now);
+        }
+
+        @Test
+        @DisplayName("totalAmount가 productPrice + shippingFee와 다르면 AmountMismatch")
+        void rejectAmountMismatch() {
+            assertThatThrownBy(() -> Order.restoreBuilder()
+                    .id(OrderId.generate())
+                    .buyer(buyer())
+                    .seller(seller())
+                    .product(product())
+                    .type(OrderType.LOW)
+                    .status(OrderStatus.REQUESTED)
+                    .shippingFee(SHIPPING)
+                    .totalAmount(Money.of(999_999))
+                    .version(0)
+                    .build())
+                    .isInstanceOf(AmountMismatchException.class);
+        }
+    }
+}

--- a/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderTest.java
@@ -82,7 +82,7 @@ class OrderTest {
     @Nested
     class HappyPath {
         @Test
-        @DisplayName("REQUESTED → COMPLETED 전체 흐름")
+        @DisplayName("REQUESTED → CONFIRMED 전체 흐름")
         void fullFlow() {
             Order order = newOrder();
 
@@ -102,12 +102,6 @@ class OrderTest {
             order.confirm(confirmedAt);
             assertThat(order.getStatus()).isEqualTo(OrderStatus.CONFIRMED);
             assertThat(order.getConfirmedAt()).isEqualTo(confirmedAt);
-
-            order.startSettlement();
-            assertThat(order.getStatus()).isEqualTo(OrderStatus.SETTLEMENT_PROCESSING);
-
-            order.complete();
-            assertThat(order.getStatus()).isEqualTo(OrderStatus.COMPLETED);
         }
 
         @Test
@@ -415,15 +409,6 @@ class OrderTest {
         @DisplayName("CONFIRMED인데 confirmedAt == null이면 RestoreStateMismatch")
         void confirmedWithoutConfirmedAt() {
             assertThatThrownBy(() -> baseBuilder(OrderStatus.CONFIRMED).build())
-                    .isInstanceOf(RestoreStateMismatchException.class);
-        }
-
-        @Test
-        @DisplayName("SETTLEMENT_PROCESSING/COMPLETED도 confirmedAt 필수")
-        void settlementCompletedWithoutConfirmedAt() {
-            assertThatThrownBy(() -> baseBuilder(OrderStatus.SETTLEMENT_PROCESSING).build())
-                    .isInstanceOf(RestoreStateMismatchException.class);
-            assertThatThrownBy(() -> baseBuilder(OrderStatus.COMPLETED).build())
                     .isInstanceOf(RestoreStateMismatchException.class);
         }
 

--- a/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderTest.java
@@ -1,7 +1,11 @@
 package com.trustamarket.orderservice.order.domain.model;
 
 import com.trustamarket.orderservice.order.domain.exception.AmountMismatchException;
+import com.trustamarket.orderservice.order.domain.exception.InvalidIdException;
+import com.trustamarket.orderservice.order.domain.exception.InvalidMoneyException;
+import com.trustamarket.orderservice.order.domain.exception.InvalidReasonException;
 import com.trustamarket.orderservice.order.domain.exception.InvalidStatusTransitionException;
+import com.trustamarket.orderservice.order.domain.exception.InvalidTimestampException;
 import com.trustamarket.orderservice.order.domain.exception.SelfPurchaseException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -56,6 +60,21 @@ class OrderTest {
 
             assertThatThrownBy(() -> Order.create(buyer, seller, product(), OrderType.LOW, SHIPPING))
                     .isInstanceOf(SelfPurchaseException.class);
+        }
+
+        @Test
+        @DisplayName("필수 인자 null이면 도메인 예외 (NPE 노출 차단)")
+        void rejectNullArguments() {
+            assertThatThrownBy(() -> Order.create(null, seller(), product(), OrderType.LOW, SHIPPING))
+                    .isInstanceOf(InvalidIdException.class);
+            assertThatThrownBy(() -> Order.create(buyer(), null, product(), OrderType.LOW, SHIPPING))
+                    .isInstanceOf(InvalidIdException.class);
+            assertThatThrownBy(() -> Order.create(buyer(), seller(), null, OrderType.LOW, SHIPPING))
+                    .isInstanceOf(InvalidIdException.class);
+            assertThatThrownBy(() -> Order.create(buyer(), seller(), product(), null, SHIPPING))
+                    .isInstanceOf(InvalidIdException.class);
+            assertThatThrownBy(() -> Order.create(buyer(), seller(), product(), OrderType.LOW, null))
+                    .isInstanceOf(InvalidMoneyException.class);
         }
     }
 
@@ -239,6 +258,68 @@ class OrderTest {
 
             assertThat(order.getDeletedAt()).isEqualTo(first);
             assertThat(order.getDeletedBy()).isEqualTo(firstUser);
+        }
+
+        @Test
+        @DisplayName("userId가 null이면 InvalidIdException")
+        void rejectNullUserId() {
+            Order order = newOrder();
+            assertThatThrownBy(() -> order.delete(null, Instant.now()))
+                    .isInstanceOf(InvalidIdException.class);
+        }
+
+        @Test
+        @DisplayName("at이 null이면 InvalidTimestampException")
+        void rejectNullAt() {
+            Order order = newOrder();
+            assertThatThrownBy(() -> order.delete(UUID.randomUUID(), null))
+                    .isInstanceOf(InvalidTimestampException.class);
+        }
+    }
+
+    @Nested
+    class NullGuards {
+        @Test
+        @DisplayName("confirm(null)은 InvalidTimestampException")
+        void confirmNull() {
+            Order order = newOrder();
+            order.requestPayment();
+            order.markPaid();
+            order.startShipping();
+            order.markDelivered();
+            assertThatThrownBy(() -> order.confirm(null))
+                    .isInstanceOf(InvalidTimestampException.class);
+        }
+
+        @Test
+        @DisplayName("cancel(null)은 InvalidReasonException")
+        void cancelNull() {
+            Order order = newOrder();
+            assertThatThrownBy(() -> order.cancel(null))
+                    .isInstanceOf(InvalidReasonException.class);
+        }
+
+        @Test
+        @DisplayName("requestReturn(null)은 InvalidReasonException")
+        void requestReturnNull() {
+            Order order = newOrder();
+            order.requestPayment();
+            order.markPaid();
+            order.startShipping();
+            assertThatThrownBy(() -> order.requestReturn(null))
+                    .isInstanceOf(InvalidReasonException.class);
+        }
+
+        @Test
+        @DisplayName("rejectReturn(null)은 InvalidReasonException")
+        void rejectReturnNull() {
+            Order order = newOrder();
+            order.requestPayment();
+            order.markPaid();
+            order.startShipping();
+            order.requestReturn(Reason.of("불량"));
+            assertThatThrownBy(() -> order.rejectReturn(null))
+                    .isInstanceOf(InvalidReasonException.class);
         }
     }
 

--- a/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderTest.java
@@ -217,26 +217,27 @@ class OrderTest {
         void delete() {
             Order order = newOrder();
             UUID userId = UUID.randomUUID();
+            Instant at = Instant.parse("2026-04-30T12:00:00Z");
 
-            order.delete(userId);
+            order.delete(userId, at);
 
             assertThat(order.isDeleted()).isTrue();
-            assertThat(order.getDeletedAt()).isNotNull();
+            assertThat(order.getDeletedAt()).isEqualTo(at);
             assertThat(order.getDeletedBy()).isEqualTo(userId);
         }
 
         @Test
         @DisplayName("이미 삭제된 엔티티에 재호출해도 최초 시각/주체 보존 (멱등성)")
-        void deleteIdempotent() throws InterruptedException {
+        void deleteIdempotent() {
             Order order = newOrder();
             UUID firstUser = UUID.randomUUID();
-            order.delete(firstUser);
-            Instant firstAt = order.getDeletedAt();
+            Instant first = Instant.parse("2026-04-30T12:00:00Z");
+            Instant later = Instant.parse("2026-04-30T13:00:00Z");
 
-            Thread.sleep(5);
-            order.delete(UUID.randomUUID());
+            order.delete(firstUser, first);
+            order.delete(UUID.randomUUID(), later);
 
-            assertThat(order.getDeletedAt()).isEqualTo(firstAt);
+            assertThat(order.getDeletedAt()).isEqualTo(first);
             assertThat(order.getDeletedBy()).isEqualTo(firstUser);
         }
     }
@@ -290,6 +291,27 @@ class OrderTest {
                     .version(0)
                     .build())
                     .isInstanceOf(AmountMismatchException.class);
+        }
+
+        @Test
+        @DisplayName("buyer.id == seller.id이면 SelfPurchase (DB 변조 감지)")
+        void rejectSelfPurchase() {
+            UUID sameId = UUID.randomUUID();
+            Buyer buyer = Buyer.of(sameId, "본인");
+            Seller seller = Seller.of(sameId, "본인");
+
+            assertThatThrownBy(() -> Order.restoreBuilder()
+                    .id(OrderId.generate())
+                    .buyer(buyer)
+                    .seller(seller)
+                    .product(product())
+                    .type(OrderType.LOW)
+                    .status(OrderStatus.REQUESTED)
+                    .shippingFee(SHIPPING)
+                    .totalAmount(PRICE.plus(SHIPPING))
+                    .version(0)
+                    .build())
+                    .isInstanceOf(SelfPurchaseException.class);
         }
     }
 }

--- a/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderTransitionTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderTransitionTest.java
@@ -1,0 +1,77 @@
+package com.trustamarket.orderservice.order.domain.model;
+
+import com.trustamarket.orderservice.order.domain.exception.InvalidStatusTransitionException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OrderTransitionTest {
+
+    @ParameterizedTest(name = "{0} + {1} -> {2}")
+    @MethodSource("validTransitions")
+    @DisplayName("허용된 전이는 다음 상태를 반환")
+    void validTransition(OrderStatus from, OrderAction action, OrderStatus expected) {
+        assertThat(OrderTransition.apply(from, action)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> validTransitions() {
+        return Stream.of(
+                // happy path
+                Arguments.of(OrderStatus.REQUESTED, OrderAction.REQUEST_PAYMENT, OrderStatus.PAYMENT_PENDING),
+                Arguments.of(OrderStatus.PAYMENT_PENDING, OrderAction.MARK_PAID, OrderStatus.PAID),
+                Arguments.of(OrderStatus.PAID, OrderAction.START_SHIPPING, OrderStatus.SHIPPING),
+                Arguments.of(OrderStatus.SHIPPING, OrderAction.MARK_DELIVERED, OrderStatus.DELIVERED),
+                Arguments.of(OrderStatus.DELIVERED, OrderAction.CONFIRM, OrderStatus.CONFIRMED),
+                Arguments.of(OrderStatus.CONFIRMED, OrderAction.START_SETTLEMENT, OrderStatus.SETTLEMENT_PROCESSING),
+                Arguments.of(OrderStatus.SETTLEMENT_PROCESSING, OrderAction.COMPLETE, OrderStatus.COMPLETED),
+                // cancel
+                Arguments.of(OrderStatus.REQUESTED, OrderAction.CANCEL, OrderStatus.CANCELLED),
+                Arguments.of(OrderStatus.PAYMENT_PENDING, OrderAction.CANCEL, OrderStatus.CANCELLED),
+                Arguments.of(OrderStatus.PAID, OrderAction.CANCEL, OrderStatus.REFUND_PROCESSING),
+                // refund
+                Arguments.of(OrderStatus.REFUND_PROCESSING, OrderAction.MARK_REFUNDED, OrderStatus.REFUND_COMPLETED),
+                // return
+                Arguments.of(OrderStatus.SHIPPING, OrderAction.REQUEST_RETURN, OrderStatus.RETURN_REQUESTED),
+                Arguments.of(OrderStatus.DELIVERED, OrderAction.REQUEST_RETURN, OrderStatus.RETURN_REQUESTED),
+                Arguments.of(OrderStatus.RETURN_REQUESTED, OrderAction.APPROVE_RETURN, OrderStatus.RETURN_APPROVED),
+                Arguments.of(OrderStatus.RETURN_REQUESTED, OrderAction.REJECT_RETURN, OrderStatus.RETURN_REJECTED)
+        );
+    }
+
+    @ParameterizedTest(name = "{0} + {1} -> 차단")
+    @MethodSource("invalidTransitions")
+    @DisplayName("허용되지 않은 전이는 InvalidStatusTransitionException")
+    void invalidTransition(OrderStatus from, OrderAction action) {
+        assertThatThrownBy(() -> OrderTransition.apply(from, action))
+                .isInstanceOf(InvalidStatusTransitionException.class);
+    }
+
+    static Stream<Arguments> invalidTransitions() {
+        return Stream.of(
+                // 종결 상태에서의 모든 액션
+                Arguments.of(OrderStatus.COMPLETED, OrderAction.CANCEL),
+                Arguments.of(OrderStatus.CANCELLED, OrderAction.REQUEST_PAYMENT),
+                Arguments.of(OrderStatus.REFUND_COMPLETED, OrderAction.CANCEL),
+                Arguments.of(OrderStatus.RETURN_REJECTED, OrderAction.APPROVE_RETURN),
+                // 배송 시작 후 취소 차단
+                Arguments.of(OrderStatus.SHIPPING, OrderAction.CANCEL),
+                Arguments.of(OrderStatus.DELIVERED, OrderAction.CANCEL),
+                // 배송 시작 전 반송 요청 차단
+                Arguments.of(OrderStatus.REQUESTED, OrderAction.REQUEST_RETURN),
+                Arguments.of(OrderStatus.PAID, OrderAction.REQUEST_RETURN),
+                // 잘못된 happy path 점프
+                Arguments.of(OrderStatus.REQUESTED, OrderAction.MARK_PAID),
+                Arguments.of(OrderStatus.PAID, OrderAction.MARK_DELIVERED),
+                Arguments.of(OrderStatus.CONFIRMED, OrderAction.COMPLETE),
+                // RETURN_APPROVED는 더 이상 OrderTransition 표에서 다음 액션 없음 (OrderReturnStatus 추적)
+                Arguments.of(OrderStatus.RETURN_APPROVED, OrderAction.COMPLETE)
+        );
+    }
+}

--- a/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderTransitionTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderTransitionTest.java
@@ -29,8 +29,6 @@ class OrderTransitionTest {
                 Arguments.of(OrderStatus.PAID, OrderAction.START_SHIPPING, OrderStatus.SHIPPING),
                 Arguments.of(OrderStatus.SHIPPING, OrderAction.MARK_DELIVERED, OrderStatus.DELIVERED),
                 Arguments.of(OrderStatus.DELIVERED, OrderAction.CONFIRM, OrderStatus.CONFIRMED),
-                Arguments.of(OrderStatus.CONFIRMED, OrderAction.START_SETTLEMENT, OrderStatus.SETTLEMENT_PROCESSING),
-                Arguments.of(OrderStatus.SETTLEMENT_PROCESSING, OrderAction.COMPLETE, OrderStatus.COMPLETED),
                 // cancel
                 Arguments.of(OrderStatus.REQUESTED, OrderAction.CANCEL, OrderStatus.CANCELLED),
                 Arguments.of(OrderStatus.PAYMENT_PENDING, OrderAction.CANCEL, OrderStatus.CANCELLED),
@@ -56,7 +54,7 @@ class OrderTransitionTest {
     static Stream<Arguments> invalidTransitions() {
         return Stream.of(
                 // 종결 상태에서의 모든 액션
-                Arguments.of(OrderStatus.COMPLETED, OrderAction.CANCEL),
+                Arguments.of(OrderStatus.CONFIRMED, OrderAction.CANCEL),
                 Arguments.of(OrderStatus.CANCELLED, OrderAction.REQUEST_PAYMENT),
                 Arguments.of(OrderStatus.REFUND_COMPLETED, OrderAction.CANCEL),
                 Arguments.of(OrderStatus.RETURN_REJECTED, OrderAction.APPROVE_RETURN),
@@ -69,9 +67,8 @@ class OrderTransitionTest {
                 // 잘못된 happy path 점프
                 Arguments.of(OrderStatus.REQUESTED, OrderAction.MARK_PAID),
                 Arguments.of(OrderStatus.PAID, OrderAction.MARK_DELIVERED),
-                Arguments.of(OrderStatus.CONFIRMED, OrderAction.COMPLETE),
-                // RETURN_APPROVED는 더 이상 OrderTransition 표에서 다음 액션 없음 (OrderReturnStatus 추적)
-                Arguments.of(OrderStatus.RETURN_APPROVED, OrderAction.COMPLETE)
+                // RETURN_APPROVED는 OrderTransition 표에서 다음 액션 없음 (OrderReturnStatus 추적)
+                Arguments.of(OrderStatus.RETURN_APPROVED, OrderAction.APPROVE_RETURN)
         );
     }
 }

--- a/src/test/java/com/trustamarket/orderservice/order/domain/model/ReasonTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/domain/model/ReasonTest.java
@@ -1,0 +1,50 @@
+package com.trustamarket.orderservice.order.domain.model;
+
+import com.trustamarket.orderservice.order.domain.exception.InvalidReasonException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReasonTest {
+
+    @Test
+    @DisplayName("of()로 사유를 생성한다")
+    void create() {
+        Reason reason = Reason.of("단순 변심");
+        assertThat(reason.value()).isEqualTo("단순 변심");
+    }
+
+    @Test
+    @DisplayName("null 사유는 거부한다")
+    void rejectNull() {
+        assertThatThrownBy(() -> Reason.of(null))
+                .isInstanceOf(InvalidReasonException.class);
+    }
+
+    @Test
+    @DisplayName("빈 문자열 사유는 거부한다")
+    void rejectBlank() {
+        assertThatThrownBy(() -> Reason.of(""))
+                .isInstanceOf(InvalidReasonException.class);
+        assertThatThrownBy(() -> Reason.of("   "))
+                .isInstanceOf(InvalidReasonException.class);
+    }
+
+    @Test
+    @DisplayName("최대 길이까지는 허용한다")
+    void allowMaxLength() {
+        String maxValue = "a".repeat(Reason.MAX_LENGTH);
+        Reason reason = Reason.of(maxValue);
+        assertThat(reason.value()).hasSize(Reason.MAX_LENGTH);
+    }
+
+    @Test
+    @DisplayName("최대 길이를 초과하면 거부한다")
+    void rejectOverMaxLength() {
+        String overValue = "a".repeat(Reason.MAX_LENGTH + 1);
+        assertThatThrownBy(() -> Reason.of(overValue))
+                .isInstanceOf(InvalidReasonException.class);
+    }
+}

--- a/src/test/java/com/trustamarket/orderservice/order/domain/model/SnapshotVoTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/domain/model/SnapshotVoTest.java
@@ -1,6 +1,7 @@
 package com.trustamarket.orderservice.order.domain.model;
 
 import com.trustamarket.orderservice.order.domain.exception.InvalidIdException;
+import com.trustamarket.orderservice.order.domain.exception.InvalidMoneyException;
 import com.trustamarket.orderservice.order.domain.exception.InvalidNameException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -99,7 +100,7 @@ class SnapshotVoTest {
         @DisplayName("price가 null이면 거부")
         void rejectNullPrice() {
             assertThatThrownBy(() -> Product.of(UUID.randomUUID(), "노트북", null))
-                    .isInstanceOf(InvalidIdException.class);
+                    .isInstanceOf(InvalidMoneyException.class);
         }
     }
 

--- a/src/test/java/com/trustamarket/orderservice/order/domain/model/SnapshotVoTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/domain/model/SnapshotVoTest.java
@@ -63,9 +63,11 @@ class SnapshotVoTest {
         }
 
         @Test
-        @DisplayName("name이 빈 문자열이면 거부")
+        @DisplayName("name이 빈/null이면 거부")
         void rejectBlankName() {
             assertThatThrownBy(() -> Seller.of(UUID.randomUUID(), "  "))
+                    .isInstanceOf(InvalidNameException.class);
+            assertThatThrownBy(() -> Seller.of(UUID.randomUUID(), null))
                     .isInstanceOf(InvalidNameException.class);
         }
     }
@@ -90,9 +92,11 @@ class SnapshotVoTest {
         }
 
         @Test
-        @DisplayName("name이 빈 문자열이면 거부")
+        @DisplayName("name이 빈/null이면 거부")
         void rejectBlankName() {
             assertThatThrownBy(() -> Product.of(UUID.randomUUID(), "", Money.of(1)))
+                    .isInstanceOf(InvalidNameException.class);
+            assertThatThrownBy(() -> Product.of(UUID.randomUUID(), null, Money.of(1)))
                     .isInstanceOf(InvalidNameException.class);
         }
 

--- a/src/test/java/com/trustamarket/orderservice/order/domain/model/SnapshotVoTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/domain/model/SnapshotVoTest.java
@@ -1,0 +1,124 @@
+package com.trustamarket.orderservice.order.domain.model;
+
+import com.trustamarket.orderservice.order.domain.exception.InvalidIdException;
+import com.trustamarket.orderservice.order.domain.exception.InvalidNameException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+// Buyer / Seller / Product snapshot VO — 동일한 검증 패턴이라 한 클래스로 묶음
+class SnapshotVoTest {
+
+    @Nested
+    class BuyerVo {
+        @Test
+        @DisplayName("정상 생성")
+        void create() {
+            UUID id = UUID.randomUUID();
+            Buyer buyer = Buyer.of(id, "홍길동");
+            assertThat(buyer.id()).isEqualTo(id);
+            assertThat(buyer.name()).isEqualTo("홍길동");
+        }
+
+        @Test
+        @DisplayName("id가 null이면 거부")
+        void rejectNullId() {
+            assertThatThrownBy(() -> Buyer.of(null, "홍길동"))
+                    .isInstanceOf(InvalidIdException.class);
+        }
+
+        @Test
+        @DisplayName("name이 빈 문자열이면 거부")
+        void rejectBlankName() {
+            UUID id = UUID.randomUUID();
+            assertThatThrownBy(() -> Buyer.of(id, ""))
+                    .isInstanceOf(InvalidNameException.class);
+            assertThatThrownBy(() -> Buyer.of(id, null))
+                    .isInstanceOf(InvalidNameException.class);
+        }
+    }
+
+    @Nested
+    class SellerVo {
+        @Test
+        @DisplayName("정상 생성")
+        void create() {
+            UUID id = UUID.randomUUID();
+            Seller seller = Seller.of(id, "스토어");
+            assertThat(seller.id()).isEqualTo(id);
+            assertThat(seller.name()).isEqualTo("스토어");
+        }
+
+        @Test
+        @DisplayName("id가 null이면 거부")
+        void rejectNullId() {
+            assertThatThrownBy(() -> Seller.of(null, "스토어"))
+                    .isInstanceOf(InvalidIdException.class);
+        }
+
+        @Test
+        @DisplayName("name이 빈 문자열이면 거부")
+        void rejectBlankName() {
+            assertThatThrownBy(() -> Seller.of(UUID.randomUUID(), "  "))
+                    .isInstanceOf(InvalidNameException.class);
+        }
+    }
+
+    @Nested
+    class ProductVo {
+        @Test
+        @DisplayName("정상 생성")
+        void create() {
+            UUID id = UUID.randomUUID();
+            Product product = Product.of(id, "노트북", Money.of(1_000_000));
+            assertThat(product.id()).isEqualTo(id);
+            assertThat(product.name()).isEqualTo("노트북");
+            assertThat(product.price().value()).isEqualTo(1_000_000);
+        }
+
+        @Test
+        @DisplayName("id가 null이면 거부")
+        void rejectNullId() {
+            assertThatThrownBy(() -> Product.of(null, "노트북", Money.of(1)))
+                    .isInstanceOf(InvalidIdException.class);
+        }
+
+        @Test
+        @DisplayName("name이 빈 문자열이면 거부")
+        void rejectBlankName() {
+            assertThatThrownBy(() -> Product.of(UUID.randomUUID(), "", Money.of(1)))
+                    .isInstanceOf(InvalidNameException.class);
+        }
+
+        @Test
+        @DisplayName("price가 null이면 거부")
+        void rejectNullPrice() {
+            assertThatThrownBy(() -> Product.of(UUID.randomUUID(), "노트북", null))
+                    .isInstanceOf(InvalidIdException.class);
+        }
+    }
+
+    @Nested
+    class OrderIdVo {
+        @Test
+        @DisplayName("generate()는 UUID를 자동 생성")
+        void generate() {
+            OrderId a = OrderId.generate();
+            OrderId b = OrderId.generate();
+            assertThat(a.value()).isNotNull();
+            assertThat(a).isNotEqualTo(b);
+        }
+
+        @Test
+        @DisplayName("of(null)은 거부")
+        void rejectNull() {
+            assertThatThrownBy(() -> OrderId.of(null))
+                    .isInstanceOf(InvalidIdException.class);
+        }
+    }
+}


### PR DESCRIPTION
## 🌱 설명

order-service의 **헥사고날 도메인 레이어**를 구현. 비즈니스 규칙·상태 머신·불변식을 순수 Java로 표현하고 JPA/Spring/HTTP 의존성을 차단. 도메인 단위 테스트 통과.

> 도메인 이벤트 record 3종은 본 PR에서 빠지고 **PR 7 (order-messaging)** 로 이관. Kafka + Outbox 패턴 도입 시점에 ECST 페이로드와 함께 정의 예정.
> 초기 계획의 식별자 VO 5종(BuyerId/SellerId/ProductId 별도) → **2종(OrderId/OrderReturnId)** 으로 통합. snapshot VO(Buyer/Seller/Product)가 UUID id를 직접 보유.

## 📌 관련 이슈

close #3

## ✅ 주요 변경 사항

- **Aggregate Root**: `Order` + 행위 메서드 12종 (모두 `OrderTransition`으로 전이 위임). 정적 팩토리 `create()` 와 DB 복원용 `restoreBuilder()` 분리. soft delete (`delete(UUID)` 멱등 + `isDeleted()`).
- **VO (Java 21 record)**: `OrderId`, `OrderReturnId` (식별자) / `Money` (plus/minus, ZERO, 음수 거부) / `Buyer`, `Seller`, `Product` (cross-domain snapshot, 주문 시점 freeze) / `Reason` (max 200자).
- **상태 머신**: `OrderTransition` table 기반 (15 transitions). `OrderAction` top-level enum 분리 (`MARK_REFUNDED` 포함). 표에 없는 (status, action) 조합은 자동 차단 (`InvalidStatusTransitionException`).
- **Enum**: `OrderStatus` (14상태, `isTerminal()` 포함), `OrderType` (LOW/HIGH), `OrderReturnStatus` (반송 워크플로우), `OrderAction`.
- **도메인 예외**: `OrderException` abstract base + 11종 비즈니스별 구체 클래스. 시그니처 `super(HttpStatus, message[, field])`. 생성자 인자는 primitive (UUID/OrderStatus/OrderAction)만 받아 VO 순환 참조 회피.
- **불변식 enforcement**: 자기구매 차단 (`SelfPurchaseException`), 총액 정합성 (`AmountMismatchException` — restore 시 검증), 음수 금액 차단 (`InvalidMoneyException`), 잘못된 전이 차단.
- **Audit 필드**: `BaseUserEntity` 미상속 (헥사고날 순수성). 도메인은 audit 필드 보유만 하고 자동 채움은 JPA 어댑터(BaseUserEntity 상속) + AuditorAware가 처리 — PR 4 영역.
- **테스트**: `MoneyTest` , `ReasonTest` , `SnapshotVoTest` , `OrderTransitionTest` , `OrderTest` . happy path / 자기구매 차단 / cancel·return 분기 / soft delete 멱등 / restore AmountMismatch 커버.
- **인프라**: `.coderabbit.yaml [12]` 룰 업데이트 (multi-Exception 클래스 허용). spring-dotenv 도입 + .env/.env.example. GitHub Packages 자격증명 fail-fast + content filter (`includeGroup 'com.trustamarket'`). Spring Security 의존성 명시.

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요? (`./gradlew test` 통과)

## 📚 추가 설명

**코드래빗 룰 [12] 변경 근거**: 비즈니스별 Exception 클래스 패턴이 단일 Exception + ErrorCode enum 보다 도메인 의도를 명확히 드러내고(클래스 이름이 곧 의도), 동적 메시지 생성이 자연스러우며, `catch (OrderNotFoundException e)` 같은 타입 기반 처리가 가능. CodeRabbit 룰을 multi-class 허용으로 업데이트.

**예외 시그니처 결정**: `ErrorCodeSpec.of(...)` 래퍼 대신 `super(HttpStatus, message[, field])` 직접 호출 — common 모듈의 `CustomException`이 그 시그니처를 제공하므로 한 단계 줄여서 도메인 코드 가독성 ↑.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 입력 검증 강화로 잘못된 금액·아이디·이름·타임스탬프에 대해 명확한 4xx 응답 제공
  * 부적절한 상태 전이는 409 응답으로 차단하고 오류 필드를 명확히 표기

* **New Features**
  * 주문 도메인에 강한 타입(금액·식별자·사유·스냅샷)과 불변성 검증 도입
  * 상세 주문 상태 흐름 및 전이 규칙, 소프트 삭제(멱등)·복원 검증 추가
  * 도메인별 표준화된 비즈니스 예외 체계 도입

* **테스트**
  * 값 객체·전이·주문 흐름에 대한 포괄적 단위 테스트 추가

* **Chores**
  * 예외 처리 정책 및 메시지/타입 가이드라인 정비
<!-- end of auto-generated comment: release notes by coderabbit.ai -->