### PR TITLE
[feature] PAID→CONFIRMED 시연 우회 + 정산 Kafka 를 Confirm 시점으로 이동

### DIFF
--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/messaging/SettlePointSettlementMessage.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/messaging/SettlePointSettlementMessage.java
@@ -3,14 +3,16 @@ package com.trustamarket.orderservice.order.adapter.out.messaging;
 import java.time.Instant;
 import java.util.UUID;
 
-// wallet-service `order.wallet-settlement.requested` 토픽 컨슈머의 payload 와 시그니처 1:1 매칭.
+// wallet-service `order.wallet-settlement.requested` 토픽 컨슈머의 payload 와 시그니처 매칭.
 // 필드 이름/순서/타입 변경 시 양쪽 동시 수정 필요 (스키마 계약).
+// productName 은 wallet/settlement 측 향후 spec 에 포함 예정 — 미리 발행 (consumer 가 unknown 필드면 무시).
 public record SettlePointSettlementMessage(
         UUID    eventId,           // 멱등성 키 — wallet 측 existsByEventId 로 중복 차단
         UUID    orderId,
         UUID    buyerId,
         UUID    sellerId,
         UUID    productId,
+        String  productName,       // 정산 시 상품 이름 표시/감사 — settlement spec 추가 예정
         long    productPrice,
         long    shippingFee,
         long    totalAmount,

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/messaging/SettlementMessagePublisher.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/messaging/SettlementMessagePublisher.java
@@ -34,10 +34,11 @@ public class SettlementMessagePublisher implements SettlementMessagePort {
                 order.getBuyer().id(),
                 order.getSeller().id(),
                 order.getProduct().id(),
+                order.getProduct().name(),
                 order.getProduct().price().value(),
                 order.getShippingFee().value(),
                 order.getTotalAmount().value(),
-                Instant.now()  // MVP — 진짜 confirm 시점은 다음 PR
+                Instant.now()
         );
 
         kafkaTemplate.send(topic, order.getId().value().toString(), message)

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/command/ConfirmOrderService.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/command/ConfirmOrderService.java
@@ -2,6 +2,7 @@ package com.trustamarket.orderservice.order.application.service.command;
 
 import com.trustamarket.orderservice.order.application.port.in.ConfirmOrderUseCase;
 import com.trustamarket.orderservice.order.application.port.out.OrderRepository;
+import com.trustamarket.orderservice.order.application.port.out.SettlementMessagePort;
 import com.trustamarket.orderservice.order.application.service.support.OrderAccessGuard;
 import com.trustamarket.orderservice.order.application.service.support.OrderHistoryRecorder;
 import com.trustamarket.orderservice.order.domain.model.Order;
@@ -13,14 +14,15 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 
-// DELIVERED → CONFIRMED (거래 종결)
-// 정산 흐름은 본 PR scope 외 (PR 4에서 SETTLEMENT_PROCESSING/COMPLETED 제거됨)
+// DELIVERED → CONFIRMED (정공) 또는 PAID → CONFIRMED (시연용 배송 우회 — OrderTransition 참조).
+// CONFIRMED 전이 직후 정산 요청 Kafka 발행 (정공 시점 — 이전 PR 의 RequestPayment 시점 발행은 임시였음).
 @Service
 @RequiredArgsConstructor
 public class ConfirmOrderService implements ConfirmOrderUseCase {
 
     private final OrderRepository orderRepository;
     private final OrderHistoryRecorder historyRecorder;
+    private final SettlementMessagePort settlementPublisher;
 
     @Override
     @Transactional
@@ -33,6 +35,8 @@ public class ConfirmOrderService implements ConfirmOrderUseCase {
         historyRecorder.record(order.getId(), pre, order.getStatus(), null);
 
         orderRepository.save(order);
-        // TODO: 다음 PR — PurchaseConfirmedEvent 발행 (Settlement 트리거)
+
+        // 정산 트리거 — 구매 확정 직후. wallet-service 의 PointSettlementListener 가 escrow→seller+fee 분배.
+        settlementPublisher.publishForPaidOrder(order);
     }
 }

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentService.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentService.java
@@ -2,7 +2,6 @@ package com.trustamarket.orderservice.order.application.service.command;
 
 import com.trustamarket.orderservice.order.application.port.in.RequestPaymentUseCase;
 import com.trustamarket.orderservice.order.application.port.out.OrderRepository;
-import com.trustamarket.orderservice.order.application.port.out.SettlementMessagePort;
 import com.trustamarket.orderservice.order.application.port.out.WalletPaymentPort;
 import com.trustamarket.orderservice.order.application.port.out.WalletPaymentPort.DeductPointRequest;
 import com.trustamarket.orderservice.order.application.port.out.WalletPaymentPort.DeductPointResponse;
@@ -26,7 +25,6 @@ public class RequestPaymentService implements RequestPaymentUseCase {
     private final OrderRepository orderRepository;
     private final OrderHistoryRecorder historyRecorder;
     private final WalletPaymentPort walletPaymentPort;
-    private final SettlementMessagePort settlementPublisher;   // adapter → port 의존 (헥사고날 경계)
 
     @Override
     @Transactional
@@ -53,9 +51,7 @@ public class RequestPaymentService implements RequestPaymentUseCase {
         historyRecorder.record(order.getId(), prePaid, order.getStatus(), null);
 
         orderRepository.save(order);
-
-        // MVP — PAID 시점에 정산 요청 발행 (정공은 Confirm 시점 + Outbox)
-        settlementPublisher.publishForPaidOrder(order);
+        // 정산 발행은 ConfirmOrderService 로 이동 (정공 시점 — 구매 확정 후 분배)
     }
 
     // Wallet 동기 호출 + null 응답/예외를 도메인 예외로 일관 변환

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderTransition.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderTransition.java
@@ -44,6 +44,10 @@ public final class OrderTransition {
             Map.entry(new Key(PAID,                  START_SHIPPING),   SHIPPING),
             Map.entry(new Key(SHIPPING,              MARK_DELIVERED),   DELIVERED),
             Map.entry(new Key(DELIVERED,             CONFIRM),          CONFIRMED),
+            // 시연용 우회 — 배송 이벤트 컨슈머가 messaging PR 진입 전이라 SHIPPING/DELIVERED 자동 전이 X.
+            // PAID 직후 사용자가 confirm 호출 가능하도록 허용 (정공은 DELIVERED 거쳐야 함).
+            // TODO: messaging PR 머지 후 본 라인 삭제 + DELIVERED 만 허용
+            Map.entry(new Key(PAID,                  CONFIRM),          CONFIRMED),
 
             // 취소 분기 (배송 시작 전까지만)
             Map.entry(new Key(REQUESTED,             CANCEL),           CANCELLED),

--- a/src/test/java/com/trustamarket/orderservice/order/application/service/command/ConfirmOrderServiceTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/application/service/command/ConfirmOrderServiceTest.java
@@ -3,6 +3,7 @@ package com.trustamarket.orderservice.order.application.service.command;
 import com.trustamarket.orderservice.order.application.exception.UnauthorizedOrderAccessException;
 import com.trustamarket.orderservice.order.application.port.in.ConfirmOrderUseCase.ConfirmOrderCommand;
 import com.trustamarket.orderservice.order.application.port.out.OrderRepository;
+import com.trustamarket.orderservice.order.application.port.out.SettlementMessagePort;
 import com.trustamarket.orderservice.order.application.service.OrderTestFixtures;
 import com.trustamarket.orderservice.order.application.service.support.OrderHistoryRecorder;
 import com.trustamarket.orderservice.order.domain.model.Order;
@@ -29,6 +30,7 @@ class ConfirmOrderServiceTest {
 
     @Mock OrderRepository orderRepository;
     @Mock OrderHistoryRecorder historyRecorder;
+    @Mock SettlementMessagePort settlementPublisher;
     @InjectMocks ConfirmOrderService service;
 
     @Test
@@ -45,6 +47,21 @@ class ConfirmOrderServiceTest {
         assertThat(order.getConfirmedAt()).isNotNull();
         verify(historyRecorder).record(order.getId(), OrderStatus.DELIVERED, OrderStatus.CONFIRMED, null);
         verify(orderRepository).save(order);
+        verify(settlementPublisher).publishForPaidOrder(order);
+    }
+
+    @Test
+    @DisplayName("PAID → CONFIRMED 시연 우회 — 정산 발행 (배송 단계 skip)")
+    void confirm_skipShippingFromPaid() {
+        UUID buyerId = UUID.randomUUID();
+        Order order = OrderTestFixtures.paidOrder(buyerId, UUID.randomUUID());  // REQUESTED → PAYMENT_PENDING → PAID
+        when(orderRepository.findByIdOrThrow(order.getId())).thenReturn(order);
+
+        service.confirm(new ConfirmOrderCommand(order.getId().value(), buyerId));
+
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.CONFIRMED);
+        verify(historyRecorder).record(order.getId(), OrderStatus.PAID, OrderStatus.CONFIRMED, null);
+        verify(settlementPublisher).publishForPaidOrder(order);
     }
 
     @Test


### PR DESCRIPTION
## 🌱 설명

배송 흐름 (`PAID → SHIPPING → DELIVERED`) 이 messaging PR 의 이벤트 컨슈머 도입 전이라 자동 전이 X. 시연에서 `Confirm` 까지 흐름을 보여주려면 `PAID` 직후 `Confirm` 가능해야 함. 동시에 정산 Kafka 발행 시점을 정공 (Confirm 직후) 으로 이동.

## 📌 관련 이슈

이슈 없음 (시연 흐름 보강)

## ✅ 주요 변경 사항

- **`OrderTransition.TABLE`** — `PAID + CONFIRM → CONFIRMED` 추가 (시연 우회). `DELIVERED + CONFIRM → CONFIRMED` 정공 라인은 그대로 유지.
  - 주석에 "messaging PR 머지 후 본 라인 삭제 + DELIVERED 만 허용" TODO 박음
- **`ConfirmOrderService`** — `SettlementMessagePort` 주입 + `confirm()` 직후 `publishForPaidOrder(order)` 호출
- **`RequestPaymentService`** — 이전 PR 의 임시 정산 발행 코드 제거 (`SettlementMessagePort` 의존도 같이)
- **`ConfirmOrderServiceTest`** — `PAID → CONFIRMED` 우회 케이스 + 정산 발행 검증 1건 추가 (총 2건)
- **`RequestPaymentServiceTest`** — `SettlementMessagePort` mock 제거

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

- 시연 흐름:
  - 4번: Request Payment → wallet 차감만 (escrow에 입금)
  - 5번: Get Order Detail → status PAID
  - 6번: Confirm Order → CONFIRMED + 정산 Kafka 발행 → wallet 컨슈머 → escrow→seller+fee 분배
- messaging PR 진입 시 `OrderTransition` 의 `PAID + CONFIRM → CONFIRMED` 라인 삭제 + `MARK_DELIVERED` 이벤트 컨슈머로 정공 흐름 복원 예정.
- 정산 발행 위치 이동에 따라 도메인 의미 명확화: payment = wallet 차감 / confirm = 정산 트리거.
- 전체 테스트 177건 통과 (기존 176 + Confirm 우회 케이스 1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 주문 확인 시 정산(결제완료 처리) 트리거가 자동으로 발행됩니다.
  * 결제된 주문이 직접 확인(PAID → CONFIRMED) 상태로 전환될 수 있도록 전환 로직이 확장되었습니다.
  * 정산 정보에 상품명이 포함되도록 메시지 페이로드가 확장되었습니다.

* **테스트**
  * 관련 경로(확인 시 정산 발행 및 PAID→CONFIRMED) 동작을 검증하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->