### PR TITLE
[feature] product-service Feign 통합 — ON_SALE 검증 + server snapshot

### DIFF
--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/product/ProductFeignClient.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/product/ProductFeignClient.java
@@ -1,0 +1,30 @@
+package com.trustamarket.orderservice.order.adapter.out.product;
+
+import com.trustamarket.common.response.CommonResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+
+// product-service 의 internal API (`GET /internal/v1/products/{id}`) 호출.
+// X-User-* 헤더는 common FeignConfig 의 RequestInterceptor 가 자동 전파.
+@FeignClient(
+        name = "product-service",
+        url = "${trusta.product-service.url:http://localhost:18081}"
+)
+public interface ProductFeignClient {
+
+    @GetMapping("/internal/v1/products/{productId}")
+    CommonResponse<ProductInfoFeignResponse> getProductInfo(@PathVariable UUID productId);
+
+    // product-service 의 ProductInfoResponse 와 1:1 매칭 (필드명/순서/타입).
+    // price 는 product-service 가 Integer — order 측은 long 받음 (자동 widening).
+    record ProductInfoFeignResponse(
+            UUID id,
+            UUID sellerId,
+            String title,
+            Long price,
+            String status
+    ) {}
+}

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/product/ProductInfoFeignAdapter.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/product/ProductInfoFeignAdapter.java
@@ -35,7 +35,8 @@ public class ProductInfoFeignAdapter implements ProductInfoPort {
                     || data.title() == null || data.title().isBlank()
                     || data.price() == null || data.price() < 0L
                     || data.status() == null || data.status().isBlank()) {
-                log.error("[Product] 응답 무결성 위반 — productId={}, data={}", productId, data);
+//                log.error("[Product] 응답 무결성 위반 — productId={}, data={}", productId, data);
+                log.warn("[Product] 응답 무결성 위반 - productId={}, reason=INVALID_PRODUCT_RESPONSE", productId);
                 throw new ProductLookupException(productId);
             }
             return new ProductInfo(

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/product/ProductInfoFeignAdapter.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/product/ProductInfoFeignAdapter.java
@@ -24,15 +24,25 @@ public class ProductInfoFeignAdapter implements ProductInfoPort {
         try {
             CommonResponse<ProductFeignClient.ProductInfoFeignResponse> resp =
                     feignClient.getProductInfo(productId);
+            if (resp == null || resp.data() == null) {
+                throw new ProductLookupException(productId);
+            }
             ProductFeignClient.ProductInfoFeignResponse data = resp.data();
-            if (data == null) {
+            // 외부 응답 엄격 검증 — 필수 필드 누락/비정상 시 fail-fast (금액 0 변환 같은 silent corruption 차단)
+            if (data.id() == null
+                    || !productId.equals(data.id())
+                    || data.sellerId() == null
+                    || data.title() == null || data.title().isBlank()
+                    || data.price() == null || data.price() < 0L
+                    || data.status() == null || data.status().isBlank()) {
+                log.error("[Product] 응답 무결성 위반 — productId={}, data={}", productId, data);
                 throw new ProductLookupException(productId);
             }
             return new ProductInfo(
                     data.id(),
                     data.sellerId(),
                     data.title(),
-                    data.price() == null ? 0L : data.price(),
+                    data.price(),
                     data.status()
             );
         } catch (FeignException e) {

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/product/ProductInfoFeignAdapter.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/product/ProductInfoFeignAdapter.java
@@ -1,0 +1,44 @@
+package com.trustamarket.orderservice.order.adapter.out.product;
+
+import com.trustamarket.common.response.CommonResponse;
+import com.trustamarket.orderservice.order.application.port.out.ProductInfoPort;
+import com.trustamarket.orderservice.order.domain.exception.ProductLookupException;
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+// ProductInfoPort 구현 — Feign 호출 + CommonResponse unwrap + 통신 실패 변환.
+// 404(상품 없음) / 5xx(통신 장애) 모두 ProductLookupException 으로 일원화.
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductInfoFeignAdapter implements ProductInfoPort {
+
+    private final ProductFeignClient feignClient;
+
+    @Override
+    public ProductInfo fetch(UUID productId) {
+        try {
+            CommonResponse<ProductFeignClient.ProductInfoFeignResponse> resp =
+                    feignClient.getProductInfo(productId);
+            ProductFeignClient.ProductInfoFeignResponse data = resp.data();
+            if (data == null) {
+                throw new ProductLookupException(productId);
+            }
+            return new ProductInfo(
+                    data.id(),
+                    data.sellerId(),
+                    data.title(),
+                    data.price() == null ? 0L : data.price(),
+                    data.status()
+            );
+        } catch (FeignException e) {
+            log.error("[Product] Feign 호출 실패 — productId={}, status={}",
+                    productId, e.status(), e);
+            throw new ProductLookupException(productId, e);
+        }
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/application/exception/ProductNotPurchasableException.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/exception/ProductNotPurchasableException.java
@@ -1,0 +1,17 @@
+package com.trustamarket.orderservice.order.application.exception;
+
+import com.trustamarket.orderservice.order.domain.exception.OrderException;
+import org.springframework.http.HttpStatus;
+
+import java.util.UUID;
+
+// 상품이 ON_SALE 상태가 아니라 주문 불가능 — 409 Conflict.
+// product-service 의 ProductStatus 가 PENDING_INSPECTION / RESERVED / SOLD_OUT 인 경우.
+public class ProductNotPurchasableException extends OrderException {
+
+    public ProductNotPurchasableException(UUID productId, String currentStatus) {
+        super(HttpStatus.CONFLICT,
+                "주문할 수 없는 상품입니다. 현재 상태: " + currentStatus,
+                "productId=" + productId);
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/application/port/out/ProductInfoPort.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/port/out/ProductInfoPort.java
@@ -1,0 +1,24 @@
+package com.trustamarket.orderservice.order.application.port.out;
+
+import java.util.UUID;
+
+// product-service 단건 조회 port — 주문 생성 시 product 가 ON_SALE 인지 검증 + snapshot fetch.
+// 구현체는 adapter/out/product 의 Feign 어댑터 (lb://product-service 또는 직접 URL).
+public interface ProductInfoPort {
+
+    ProductInfo fetch(UUID productId);
+
+    // 주문 도메인이 필요한 최소 필드만. product-service 의 ProductInfoResponse 와 1:1 매칭.
+    // status 는 String — order 측에 ProductStatus enum 두지 않기 위해 (cross-service enum 결합 회피).
+    record ProductInfo(
+            UUID id,
+            UUID sellerId,
+            String name,
+            long price,
+            String status
+    ) {
+        public boolean isOnSale() {
+            return "ON_SALE".equals(status);
+        }
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/application/port/out/ProductInfoPort.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/port/out/ProductInfoPort.java
@@ -17,6 +17,14 @@ public interface ProductInfoPort {
             long price,
             String status
     ) {
+        public ProductInfo {
+            if (id == null) throw new IllegalArgumentException("product id must not be null");
+            if (sellerId == null) throw new IllegalArgumentException("seller id must not be null");
+            if (name == null || name.isBlank()) throw new IllegalArgumentException("product name must not be blank");
+            if (status == null || status.isBlank()) throw new IllegalArgumentException("product status must not be blank");
+            if (price < 0L) throw new IllegalArgumentException("product price must be >= 0");
+        }
+
         public boolean isOnSale() {
             return "ON_SALE".equals(status);
         }

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/command/CreateOrderService.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/command/CreateOrderService.java
@@ -1,8 +1,11 @@
 package com.trustamarket.orderservice.order.application.service.command;
 
 import com.trustamarket.orderservice.order.application.dto.result.CreateOrderResult;
+import com.trustamarket.orderservice.order.application.exception.ProductNotPurchasableException;
 import com.trustamarket.orderservice.order.application.port.in.CreateOrderUseCase;
 import com.trustamarket.orderservice.order.application.port.out.OrderRepository;
+import com.trustamarket.orderservice.order.application.port.out.ProductInfoPort;
+import com.trustamarket.orderservice.order.application.port.out.ProductInfoPort.ProductInfo;
 import com.trustamarket.orderservice.order.application.service.support.OrderHistoryRecorder;
 import com.trustamarket.orderservice.order.domain.model.Buyer;
 import com.trustamarket.orderservice.order.domain.model.Money;
@@ -20,14 +23,21 @@ public class CreateOrderService implements CreateOrderUseCase {
 
     private final OrderRepository orderRepository;
     private final OrderHistoryRecorder historyRecorder;
+    private final ProductInfoPort productInfoPort;
 
     @Override
     @Transactional
     public CreateOrderResult createOrder(CreateOrderCommand cmd) {
+        // product-service 검증 — ON_SALE 인 상품만 주문 생성 가능. 가격/이름은 server snapshot 사용 (client 입력 무시 — 변조 방지).
+        ProductInfo product = productInfoPort.fetch(cmd.productId());
+        if (!product.isOnSale()) {
+            throw new ProductNotPurchasableException(cmd.productId(), product.status());
+        }
+
         Order order = Order.create(
                 Buyer.of(cmd.buyerId(), cmd.buyerName()),
-                Seller.of(cmd.sellerId(), cmd.sellerName()),
-                Product.of(cmd.productId(), cmd.productName(), Money.of(cmd.productPrice())),
+                Seller.of(product.sellerId(), cmd.sellerName()),    // sellerId 도 product-service 진실
+                Product.of(product.id(), product.name(), Money.of(product.price())),
                 cmd.type(),
                 Money.of(cmd.shippingFee())
         );

--- a/src/main/java/com/trustamarket/orderservice/order/domain/exception/ProductLookupException.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/exception/ProductLookupException.java
@@ -1,0 +1,21 @@
+package com.trustamarket.orderservice.order.domain.exception;
+
+import org.springframework.http.HttpStatus;
+
+import java.util.UUID;
+
+// product-service 조회 실패 (404 / 통신 장애 / 빈 응답) 통합 예외.
+// 502 Bad Gateway — wallet 의 WalletCommunicationException 과 동일한 정책.
+public class ProductLookupException extends OrderException {
+
+    private static final String USER_MESSAGE = "상품 정보를 조회할 수 없습니다. 잠시 후 다시 시도해주세요.";
+
+    public ProductLookupException(UUID productId) {
+        super(HttpStatus.BAD_GATEWAY, USER_MESSAGE, "productId=" + productId);
+    }
+
+    public ProductLookupException(UUID productId, Throwable cause) {
+        super(HttpStatus.BAD_GATEWAY, USER_MESSAGE, "productId=" + productId);
+        initCause(cause);
+    }
+}

--- a/src/test/java/com/trustamarket/orderservice/order/application/service/command/CreateOrderServiceTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/application/service/command/CreateOrderServiceTest.java
@@ -20,6 +20,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.UUID;
 
+import org.mockito.ArgumentCaptor;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -57,8 +59,15 @@ class CreateOrderServiceTest {
         assertThat(result).isNotNull();
         assertThat(result.status()).isEqualTo(OrderStatus.REQUESTED);
         assertThat(result.totalAmount()).isEqualTo(103_000L);   // 100k(server price) + 3k shipping
-        verify(orderRepository).save(any(Order.class));
         verify(historyRecorder).record(any(OrderId.class), eq(null), eq(OrderStatus.REQUESTED), eq(null));
+
+        // server snapshot 우선 검증 — sellerId / productName / productPrice 모두 product-service 진실값 사용 (client 입력 무시)
+        ArgumentCaptor<Order> captor = ArgumentCaptor.forClass(Order.class);
+        verify(orderRepository).save(captor.capture());
+        Order saved = captor.getValue();
+        assertThat(saved.getSeller().id()).isEqualTo(sellerId);          // ProductInfo 의 sellerId
+        assertThat(saved.getProduct().name()).isEqualTo("정공-상품명");    // ProductInfo 의 name (cmd 의 "client-claim-name" 아님)
+        assertThat(saved.getProduct().price().value()).isEqualTo(100_000L);  // ProductInfo 의 price (cmd 의 999L 아님)
     }
 
     @Test

--- a/src/test/java/com/trustamarket/orderservice/order/application/service/command/CreateOrderServiceTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/application/service/command/CreateOrderServiceTest.java
@@ -1,8 +1,11 @@
 package com.trustamarket.orderservice.order.application.service.command;
 
 import com.trustamarket.orderservice.order.application.dto.result.CreateOrderResult;
+import com.trustamarket.orderservice.order.application.exception.ProductNotPurchasableException;
 import com.trustamarket.orderservice.order.application.port.in.CreateOrderUseCase.CreateOrderCommand;
 import com.trustamarket.orderservice.order.application.port.out.OrderRepository;
+import com.trustamarket.orderservice.order.application.port.out.ProductInfoPort;
+import com.trustamarket.orderservice.order.application.port.out.ProductInfoPort.ProductInfo;
 import com.trustamarket.orderservice.order.application.service.support.OrderHistoryRecorder;
 import com.trustamarket.orderservice.order.domain.model.Order;
 import com.trustamarket.orderservice.order.domain.model.OrderId;
@@ -18,8 +21,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -28,27 +33,51 @@ class CreateOrderServiceTest {
 
     @Mock OrderRepository orderRepository;
     @Mock OrderHistoryRecorder historyRecorder;
+    @Mock ProductInfoPort productInfoPort;
     @InjectMocks CreateOrderService service;
 
     @Test
-    @DisplayName("주문 생성 — happy path")
+    @DisplayName("주문 생성 — happy path (product ON_SALE)")
     void createOrder() {
+        UUID productId = UUID.randomUUID();
+        UUID sellerId = UUID.randomUUID();
         CreateOrderCommand cmd = new CreateOrderCommand(
                 UUID.randomUUID(), "구매자",
                 UUID.randomUUID(), "판매자",
-                UUID.randomUUID(), "상품", 100_000L,
+                productId, "client-claim-name", 999L,   // client 입력은 무시되어야 함 (server snapshot 사용)
                 OrderType.LOW,
                 3_000L
         );
+        when(productInfoPort.fetch(productId)).thenReturn(
+                new ProductInfo(productId, sellerId, "정공-상품명", 100_000L, "ON_SALE"));
         when(orderRepository.save(any(Order.class))).thenAnswer(inv -> inv.getArgument(0));
 
         CreateOrderResult result = service.createOrder(cmd);
 
         assertThat(result).isNotNull();
         assertThat(result.status()).isEqualTo(OrderStatus.REQUESTED);
-        assertThat(result.totalAmount()).isEqualTo(103_000L);
+        assertThat(result.totalAmount()).isEqualTo(103_000L);   // 100k(server price) + 3k shipping
         verify(orderRepository).save(any(Order.class));
-        // 신규 생성: prev=null, next=REQUESTED
         verify(historyRecorder).record(any(OrderId.class), eq(null), eq(OrderStatus.REQUESTED), eq(null));
+    }
+
+    @Test
+    @DisplayName("product 가 ON_SALE 아니면 → ProductNotPurchasableException + 주문 저장 X")
+    void createOrder_notOnSale_rejects() {
+        UUID productId = UUID.randomUUID();
+        CreateOrderCommand cmd = new CreateOrderCommand(
+                UUID.randomUUID(), "구매자",
+                UUID.randomUUID(), "판매자",
+                productId, "상품", 100_000L,
+                OrderType.LOW,
+                3_000L
+        );
+        when(productInfoPort.fetch(productId)).thenReturn(
+                new ProductInfo(productId, UUID.randomUUID(), "검수중상품", 100_000L, "PENDING_INSPECTION"));
+
+        assertThatThrownBy(() -> service.createOrder(cmd))
+                .isInstanceOf(ProductNotPurchasableException.class);
+
+        verify(orderRepository, never()).save(any(Order.class));
     }
 }


### PR DESCRIPTION
## 🌱 설명

주문 생성 시 product-service 의 internal API 를 Feign 으로 호출해서 product 가 `ON_SALE` 인지 검증 + server-side snapshot (name/price/sellerId) 사용.
클라이언트가 보낸 productName/productPrice/sellerId 는 무시 (변조 방지).

## 📌 관련 이슈

이슈 없음 (시연 흐름 cross-service 통신 추가)

## ✅ 주요 변경 사항

- **`ProductInfoPort`** — application 포트 (out). `ProductInfo` record 에 `isOnSale()` 헬퍼.
- **`ProductFeignClient`** — `@FeignClient(name="product-service", url="${trusta.product-service.url:http://localhost:18081}")` + `GET /internal/v1/products/{productId}`
- **`ProductInfoFeignAdapter`** — port 구현. `CommonResponse<>` unwrap + `FeignException` → `ProductLookupException` 변환
- **`ProductLookupException`** (502 — wallet 과 동일 정책)
- **`ProductNotPurchasableException`** (409 — ON_SALE 아닐 때)
- **`CreateOrderService`** 변경:
  - `productInfoPort.fetch(productId)` 호출
  - `isOnSale()` false → `ProductNotPurchasableException`
  - Order 생성 시 **server snapshot (name/price/sellerId) 사용** (client 입력 무시)
- **테스트** — happy path (ON_SALE) + `PENDING_INSPECTION` → 거부 = 2건 추가 (총 178 통과)

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

- product-service 측 PR (`[feature] product internal API`) 머지가 선행되어야 시연 동작.
- 시연 흐름 보강: 상품 등록 → ON_SALE 인 상품만 주문 가능. 검수 대기 (`PENDING_INSPECTION`) 상품은 409 거부.
- common `FeignConfig` 가 X-User-* / Authorization 헤더 자동 전파 (별도 작업 X).
- 향후: 가격 변경 timing race, soft-cache, eventual consistency 같은 advanced 흐름은 messaging PR 또는 별도 PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 주문 생성 시 상품의 최신 스냅샷을 조회해 주문에 반영하도록 추가
  * 조회된 상품의 상태·가격·판매자 정보로 주문 항목을 결정

* **버그 수정**
  * 상품 조회 실패 및 비구매 가능 상태에 대해 명확한 오류 응답(중개 실패/비구매 가능) 처리 강화
  * 조회 응답의 무결성 검증 강화(필수 필드·가격 검증 등)

* **테스트**
  * 상품 서비스 응답 기반 성공·실패 시나리오를 검증하는 단위 테스트 추가·갱신
<!-- end of auto-generated comment: release notes by coderabbit.ai -->