### PR TITLE
[feature] 주문 endpoint 복수형 정리 + product sold-out Kafka publish

### DIFF
--- a/src/main/java/com/trustamarket/orderservice/order/adapter/in/web/OrderCommandController.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/in/web/OrderCommandController.java
@@ -53,7 +53,7 @@ public class OrderCommandController {
         );
     }
 
-    @PostMapping("/api/v1/orders/{orderId}/payment")
+    @PostMapping("/api/v1/orders/{orderId}/payments")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasRole('MEMBER')")
     public void requestPayment(@PathVariable UUID orderId) {
@@ -61,7 +61,7 @@ public class OrderCommandController {
         requestPaymentUseCase.requestPayment(new RequestPaymentCommand(orderId, buyerId));
     }
 
-    @PostMapping("/api/v1/orders/{orderId}/cancel")
+    @PostMapping("/api/v1/orders/{orderId}/cancellations")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasAnyRole('MEMBER','ADMIN')")
     public void cancel(@PathVariable UUID orderId, @Valid @RequestBody CancelOrderRequest request) {
@@ -69,7 +69,7 @@ public class OrderCommandController {
         cancelOrderUseCase.cancel(request.toCommand(orderId, actorId));
     }
 
-    @PostMapping("/api/v1/orders/{orderId}/confirm")
+    @PostMapping("/api/v1/orders/{orderId}/confirmations")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasRole('MEMBER')")
     public void confirm(@PathVariable UUID orderId) {
@@ -77,7 +77,7 @@ public class OrderCommandController {
         confirmOrderUseCase.confirm(new ConfirmOrderCommand(orderId, buyerId));
     }
 
-    @PostMapping("/api/v1/orders/{orderId}/return")
+    @PostMapping("/api/v1/orders/{orderId}/returns")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasRole('MEMBER')")
     public void requestReturn(@PathVariable UUID orderId, @Valid @RequestBody RequestReturnRequest request) {
@@ -85,7 +85,7 @@ public class OrderCommandController {
         requestReturnUseCase.requestReturn(request.toCommand(orderId, buyerId));
     }
 
-    @PostMapping("/api/v1/admin/orders/{orderId}/return/decision")
+    @PostMapping("/api/v1/admin/orders/{orderId}/returns/decisions")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasRole('ADMIN')")
     public void decideReturn(@PathVariable UUID orderId, @Valid @RequestBody DecideReturnRequest request) {

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/in/web/OrderQueryController.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/in/web/OrderQueryController.java
@@ -104,7 +104,7 @@ public class OrderQueryController {
                 .map(OrderSummaryResponse::from);
     }
 
-    @GetMapping("/api/v1/admin/orders/{orderId}/status-history")
+    @GetMapping("/api/v1/admin/orders/{orderId}/status-histories")
     @PreAuthorize("hasRole('ADMIN')")
     public List<OrderStatusHistoryResponse> getStatusHistory(@PathVariable UUID orderId) {
         return getStatusHistoryUseCase.getHistory(orderId).stream()

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/messaging/ProductSoldOutMessage.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/messaging/ProductSoldOutMessage.java
@@ -1,0 +1,13 @@
+package com.trustamarket.orderservice.order.adapter.out.messaging;
+
+import java.time.Instant;
+import java.util.UUID;
+
+// 주문 확정 직후 product 가 SOLD_OUT 으로 전이되도록 발행하는 이벤트.
+// product-service 의 ProductSoldOutListener 가 구독.
+public record ProductSoldOutMessage(
+        UUID eventId,
+        UUID orderId,
+        UUID productId,
+        Instant soldAt
+) {}

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/messaging/ProductSoldOutMessagePublisher.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/messaging/ProductSoldOutMessagePublisher.java
@@ -1,0 +1,45 @@
+package com.trustamarket.orderservice.order.adapter.out.messaging;
+
+import com.trustamarket.orderservice.order.application.port.out.ProductSoldOutMessagePort;
+import com.trustamarket.orderservice.order.domain.model.Order;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductSoldOutMessagePublisher implements ProductSoldOutMessagePort {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Value("${trusta.messaging.topic.product-sold-out}")
+    private String topic;
+
+    @Override
+    public void publishForConfirmedOrder(Order order) {
+        UUID eventId = UUID.randomUUID();
+        ProductSoldOutMessage message = new ProductSoldOutMessage(
+                eventId,
+                order.getId().value(),
+                order.getProduct().id(),
+                Instant.now()
+        );
+
+        kafkaTemplate.send(topic, order.getProduct().id().toString(), message)
+                .whenComplete((res, ex) -> {
+                    if (ex != null) {
+                        log.error("[ProductSoldOut] 발행 실패 — eventId={}, productId={}",
+                                eventId, order.getProduct().id(), ex);
+                    } else {
+                        log.info("[ProductSoldOut] 발행 — eventId={}, productId={}",
+                                eventId, order.getProduct().id());
+                    }
+                });
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/application/port/out/ProductSoldOutMessagePort.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/port/out/ProductSoldOutMessagePort.java
@@ -1,0 +1,8 @@
+package com.trustamarket.orderservice.order.application.port.out;
+
+import com.trustamarket.orderservice.order.domain.model.Order;
+
+// 주문 확정 직후 product 도메인에 판매완료 신호 (Kafka). product-service 가 consume.
+public interface ProductSoldOutMessagePort {
+    void publishForConfirmedOrder(Order order);
+}

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/command/ConfirmOrderService.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/command/ConfirmOrderService.java
@@ -2,6 +2,7 @@ package com.trustamarket.orderservice.order.application.service.command;
 
 import com.trustamarket.orderservice.order.application.port.in.ConfirmOrderUseCase;
 import com.trustamarket.orderservice.order.application.port.out.OrderRepository;
+import com.trustamarket.orderservice.order.application.port.out.ProductSoldOutMessagePort;
 import com.trustamarket.orderservice.order.application.port.out.SettlementMessagePort;
 import com.trustamarket.orderservice.order.application.service.support.OrderAccessGuard;
 import com.trustamarket.orderservice.order.application.service.support.OrderHistoryRecorder;
@@ -23,6 +24,7 @@ public class ConfirmOrderService implements ConfirmOrderUseCase {
     private final OrderRepository orderRepository;
     private final OrderHistoryRecorder historyRecorder;
     private final SettlementMessagePort settlementPublisher;
+    private final ProductSoldOutMessagePort productSoldOutPublisher;
 
     @Override
     @Transactional
@@ -38,5 +40,8 @@ public class ConfirmOrderService implements ConfirmOrderUseCase {
 
         // 정산 트리거 — 구매 확정 직후. wallet-service 의 PointSettlementListener 가 escrow→seller+fee 분배.
         settlementPublisher.publishForPaidOrder(order);
+
+        // product 도메인에 판매완료 신호 — product-service 의 ProductSoldOutListener 가 status SOLD_OUT 으로 전이.
+        productSoldOutPublisher.publishForConfirmedOrder(order);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,3 +27,4 @@ trusta:
   messaging:
     topic:
       settlement-requested: order.wallet-settlement.requested
+      product-sold-out:    order.product.sold-out

--- a/src/test/java/com/trustamarket/orderservice/order/adapter/in/web/OrderCommandControllerTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/adapter/in/web/OrderCommandControllerTest.java
@@ -135,12 +135,12 @@ class OrderCommandControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
-    // ─── POST /api/v1/orders/{id}/payment ───
+    // ─── POST /api/v1/orders/{id}/payments ───
 
     @Test
     @DisplayName("requestPayment — 204")
     void requestPayment_happyPath() throws Exception {
-        mockMvc.perform(post("/api/v1/orders/{id}/payment", orderId)
+        mockMvc.perform(post("/api/v1/orders/{id}/payments", orderId)
                         .with(authentication(TestAuth.memberAuth(buyerId, "구매자")))
                         .with(csrf()))
                 .andExpect(status().isNoContent());
@@ -150,7 +150,7 @@ class OrderCommandControllerTest {
     @Test
     @DisplayName("requestPayment — 인증 없음 → 401")
     void requestPayment_unauthenticated() throws Exception {
-        mockMvc.perform(post("/api/v1/orders/{id}/payment", orderId)
+        mockMvc.perform(post("/api/v1/orders/{id}/payments", orderId)
                         .with(csrf()))
                 .andExpect(status().isUnauthorized());
     }
@@ -158,18 +158,18 @@ class OrderCommandControllerTest {
     @Test
     @DisplayName("requestPayment — ADMIN 거부 → 403")
     void requestPayment_forbiddenForAdmin() throws Exception {
-        mockMvc.perform(post("/api/v1/orders/{id}/payment", orderId)
+        mockMvc.perform(post("/api/v1/orders/{id}/payments", orderId)
                         .with(authentication(TestAuth.adminAuth(UUID.randomUUID())))
                         .with(csrf()))
                 .andExpect(status().isForbidden());
     }
 
-    // ─── POST /api/v1/orders/{id}/cancel ───
+    // ─── POST /api/v1/orders/{id}/cancellations ───
 
     @Test
     @DisplayName("cancel — 204 (MEMBER)")
     void cancel_happyPath_member() throws Exception {
-        mockMvc.perform(post("/api/v1/orders/{id}/cancel", orderId)
+        mockMvc.perform(post("/api/v1/orders/{id}/cancellations", orderId)
                         .with(authentication(TestAuth.memberAuth(buyerId, "구매자")))
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
@@ -181,7 +181,7 @@ class OrderCommandControllerTest {
     @Test
     @DisplayName("cancel — 204 (ADMIN 도 허용)")
     void cancel_happyPath_admin() throws Exception {
-        mockMvc.perform(post("/api/v1/orders/{id}/cancel", orderId)
+        mockMvc.perform(post("/api/v1/orders/{id}/cancellations", orderId)
                         .with(authentication(TestAuth.adminAuth(UUID.randomUUID())))
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
@@ -192,7 +192,7 @@ class OrderCommandControllerTest {
     @Test
     @DisplayName("cancel — reason blank → 400")
     void cancel_blankReason() throws Exception {
-        mockMvc.perform(post("/api/v1/orders/{id}/cancel", orderId)
+        mockMvc.perform(post("/api/v1/orders/{id}/cancellations", orderId)
                         .with(authentication(TestAuth.memberAuth(buyerId, "구매자")))
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
@@ -203,19 +203,19 @@ class OrderCommandControllerTest {
     @Test
     @DisplayName("cancel — 인증 없음 → 401")
     void cancel_unauthenticated() throws Exception {
-        mockMvc.perform(post("/api/v1/orders/{id}/cancel", orderId)
+        mockMvc.perform(post("/api/v1/orders/{id}/cancellations", orderId)
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new CancelOrderRequest("변심"))))
                 .andExpect(status().isUnauthorized());
     }
 
-    // ─── POST /api/v1/orders/{id}/confirm ───
+    // ─── POST /api/v1/orders/{id}/confirmations ───
 
     @Test
     @DisplayName("confirm — 204")
     void confirm_happyPath() throws Exception {
-        mockMvc.perform(post("/api/v1/orders/{id}/confirm", orderId)
+        mockMvc.perform(post("/api/v1/orders/{id}/confirmations", orderId)
                         .with(authentication(TestAuth.memberAuth(buyerId, "구매자")))
                         .with(csrf()))
                 .andExpect(status().isNoContent());
@@ -225,7 +225,7 @@ class OrderCommandControllerTest {
     @Test
     @DisplayName("confirm — 인증 없음 → 401")
     void confirm_unauthenticated() throws Exception {
-        mockMvc.perform(post("/api/v1/orders/{id}/confirm", orderId)
+        mockMvc.perform(post("/api/v1/orders/{id}/confirmations", orderId)
                         .with(csrf()))
                 .andExpect(status().isUnauthorized());
     }
@@ -233,18 +233,18 @@ class OrderCommandControllerTest {
     @Test
     @DisplayName("confirm — ADMIN 거부 → 403")
     void confirm_forbiddenForAdmin() throws Exception {
-        mockMvc.perform(post("/api/v1/orders/{id}/confirm", orderId)
+        mockMvc.perform(post("/api/v1/orders/{id}/confirmations", orderId)
                         .with(authentication(TestAuth.adminAuth(UUID.randomUUID())))
                         .with(csrf()))
                 .andExpect(status().isForbidden());
     }
 
-    // ─── POST /api/v1/orders/{id}/return ───
+    // ─── POST /api/v1/orders/{id}/returns ───
 
     @Test
     @DisplayName("requestReturn — 204")
     void requestReturn_happyPath() throws Exception {
-        mockMvc.perform(post("/api/v1/orders/{id}/return", orderId)
+        mockMvc.perform(post("/api/v1/orders/{id}/returns", orderId)
                         .with(authentication(TestAuth.memberAuth(buyerId, "구매자")))
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
@@ -256,7 +256,7 @@ class OrderCommandControllerTest {
     @Test
     @DisplayName("requestReturn — 인증 없음 → 401")
     void requestReturn_unauthenticated() throws Exception {
-        mockMvc.perform(post("/api/v1/orders/{id}/return", orderId)
+        mockMvc.perform(post("/api/v1/orders/{id}/returns", orderId)
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new RequestReturnRequest("불량"))))
@@ -266,7 +266,7 @@ class OrderCommandControllerTest {
     @Test
     @DisplayName("requestReturn — reason blank → 400")
     void requestReturn_blankReason() throws Exception {
-        mockMvc.perform(post("/api/v1/orders/{id}/return", orderId)
+        mockMvc.perform(post("/api/v1/orders/{id}/returns", orderId)
                         .with(authentication(TestAuth.memberAuth(buyerId, "구매자")))
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
@@ -274,12 +274,12 @@ class OrderCommandControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
-    // ─── POST /api/v1/admin/orders/{id}/return/decision ───
+    // ─── POST /api/v1/admin/orders/{id}/returns/decisions ───
 
     @Test
     @DisplayName("decideReturn — 204 (ADMIN, APPROVE)")
     void decideReturn_happyPath_approve() throws Exception {
-        mockMvc.perform(post("/api/v1/admin/orders/{id}/return/decision", orderId)
+        mockMvc.perform(post("/api/v1/admin/orders/{id}/returns/decisions", orderId)
                         .with(authentication(TestAuth.adminAuth(UUID.randomUUID())))
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
@@ -292,7 +292,7 @@ class OrderCommandControllerTest {
     @Test
     @DisplayName("decideReturn — 204 (ADMIN, REJECT + reason)")
     void decideReturn_happyPath_reject() throws Exception {
-        mockMvc.perform(post("/api/v1/admin/orders/{id}/return/decision", orderId)
+        mockMvc.perform(post("/api/v1/admin/orders/{id}/returns/decisions", orderId)
                         .with(authentication(TestAuth.adminAuth(UUID.randomUUID())))
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
@@ -304,7 +304,7 @@ class OrderCommandControllerTest {
     @Test
     @DisplayName("decideReturn — MEMBER 거부 → 403")
     void decideReturn_forbiddenForMember() throws Exception {
-        mockMvc.perform(post("/api/v1/admin/orders/{id}/return/decision", orderId)
+        mockMvc.perform(post("/api/v1/admin/orders/{id}/returns/decisions", orderId)
                         .with(authentication(TestAuth.memberAuth(buyerId, "구매자")))
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
@@ -316,7 +316,7 @@ class OrderCommandControllerTest {
     @Test
     @DisplayName("decideReturn — 인증 없음 → 401")
     void decideReturn_unauthenticated() throws Exception {
-        mockMvc.perform(post("/api/v1/admin/orders/{id}/return/decision", orderId)
+        mockMvc.perform(post("/api/v1/admin/orders/{id}/returns/decisions", orderId)
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(

--- a/src/test/java/com/trustamarket/orderservice/order/adapter/in/web/OrderQueryControllerTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/adapter/in/web/OrderQueryControllerTest.java
@@ -249,7 +249,7 @@ class OrderQueryControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
-    // ─── GET /api/v1/admin/orders/{id}/status-history ───
+    // ─── GET /api/v1/admin/orders/{id}/status-histories ───
 
     @Test
     @DisplayName("getStatusHistory — 200 (ADMIN)")
@@ -258,7 +258,7 @@ class OrderQueryControllerTest {
                 UUID.randomUUID(), null, OrderStatus.REQUESTED, "최초 생성");
         when(getStatusHistoryUseCase.getHistory(orderUuid)).thenReturn(List.of(v));
 
-        mockMvc.perform(get("/api/v1/admin/orders/{id}/status-history", orderUuid)
+        mockMvc.perform(get("/api/v1/admin/orders/{id}/status-histories", orderUuid)
                         .with(authentication(TestAuth.adminAuth(UUID.randomUUID()))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isArray())
@@ -268,7 +268,7 @@ class OrderQueryControllerTest {
     @Test
     @DisplayName("getStatusHistory — MEMBER 거부 → 403")
     void getStatusHistory_forbiddenForMember() throws Exception {
-        mockMvc.perform(get("/api/v1/admin/orders/{id}/status-history", orderUuid)
+        mockMvc.perform(get("/api/v1/admin/orders/{id}/status-histories", orderUuid)
                         .with(authentication(TestAuth.memberAuth(memberUuid, "구매자"))))
                 .andExpect(status().isForbidden());
     }
@@ -276,7 +276,7 @@ class OrderQueryControllerTest {
     @Test
     @DisplayName("getStatusHistory — 인증 없음 → 401")
     void getStatusHistory_unauthenticated() throws Exception {
-        mockMvc.perform(get("/api/v1/admin/orders/{id}/status-history", orderUuid))
+        mockMvc.perform(get("/api/v1/admin/orders/{id}/status-histories", orderUuid))
                 .andExpect(status().isUnauthorized());
     }
 }


### PR DESCRIPTION
## 🌱 설명

주문 서비스에 두 가지 변경. (1) 액션 endpoint 를 RESTful 복수형 명사 컨벤션으로 통일 (2) 구매 확정 시 product sold-out Kafka 발행 — product-service 가 컨슘해서 status SOLD_OUT 으로 전이하게.

## 📌 관련 이슈

close #

## ✅ 주요 변경 사항

- 주문 액션 endpoint 6개 복수형 명사로 rename:
  - `/payment` → `/payments`
  - `/cancel` → `/cancellations`
  - `/confirm` → `/confirmations`
  - `/return` → `/returns`
  - `/admin/.../return/decision` → `/admin/.../returns/decisions`
  - `/admin/.../status-history` → `/admin/.../status-histories`
- product sold-out Kafka publish:
  - `ProductSoldOutMessagePort` (out port) + `ProductSoldOutMessagePublisher` (Kafka adapter, settlement publisher 패턴 동일)
  - `ConfirmOrderService` 가 confirm 직후 settlement publish 와 함께 호출
  - 토픽: `order.product.sold-out` (application.yaml 의 `trusta.messaging.topic.product-sold-out`)
  - payload: `ProductSoldOutMessage(eventId, orderId, productId, soldAt)`

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

- product-service 측 PR (`feature/N-product-soldout-listener`) 과 짝. **product PR 먼저 머지 권장** — consumer 가 준비된 후 publisher 가 시작해야 첫 메시지 누락 위험 0.
- consumer 측은 `auto-offset-reset=earliest` 라 publisher 가 먼저 들어와도 join 시 이전 메시지 받기는 가능. 그래도 정공 순서 권장.
- 본 PR 의 endpoint rename 은 Postman 컬렉션 (ignoredocs) + 명세 (Notion) 와 동기화 완료.
- ConfirmOrderServiceTest 는 새 dependency (`ProductSoldOutMessagePort`) Mock 추가 필요할 수 있음 — 별도 commit 으로 보강 예정.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 주문 확인 시 제품 판매 완료 신호를 메시징 시스템으로 발행하도록 추가
  * REST API 경로를 복수형으로 표준화하여 엔드포인트 명칭 일관성 개선

* **테스트**
  * 변경된 복수형 경로에 맞춰 관련 엔드포인트 테스트 업데이트

* **Chores**
  * 제품 판매 완료 메시징 토픽 설정 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->