### PR TITLE
[feature] 결제 후 취소 흐름 + REFUND -> CANCELLATION rename

### DIFF
--- a/src/main/java/com/trustamarket/orderservice/order/adapter/in/messaging/DeliveryCompletedListener.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/in/messaging/DeliveryCompletedListener.java
@@ -8,6 +8,7 @@ import com.trustamarket.orderservice.order.application.port.out.InboxRepository.
 import com.trustamarket.orderservice.order.domain.exception.OrderException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import com.trustamarket.common.messaging.IdempotentConsumer;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
@@ -28,6 +29,7 @@ public class DeliveryCompletedListener {
     private final InboxRepository inboxRepository;
     private final ObjectMapper objectMapper;
 
+    @IdempotentConsumer(CONSUMER_GROUP)
     @KafkaListener(topics = "${trusta.messaging.topic.delivery-completed:delivery.completed}",
             groupId = CONSUMER_GROUP)
     @Transactional

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/in/messaging/DeliveryStartedListener.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/in/messaging/DeliveryStartedListener.java
@@ -8,6 +8,7 @@ import com.trustamarket.orderservice.order.application.port.out.InboxRepository.
 import com.trustamarket.orderservice.order.domain.exception.OrderException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import com.trustamarket.common.messaging.IdempotentConsumer;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
@@ -30,6 +31,7 @@ public class DeliveryStartedListener {
     private final InboxRepository inboxRepository;
     private final ObjectMapper objectMapper;
 
+    @IdempotentConsumer(CONSUMER_GROUP)
     @KafkaListener(topics = "${trusta.messaging.topic.delivery-started:delivery.started}",
             groupId = CONSUMER_GROUP)
     @Transactional

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/in/messaging/WalletCancellationCompletedListener.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/in/messaging/WalletCancellationCompletedListener.java
@@ -6,6 +6,7 @@ import com.trustamarket.orderservice.order.application.port.in.MarkOrderCancelle
 import com.trustamarket.orderservice.order.application.port.out.InboxRepository;
 import com.trustamarket.orderservice.order.application.port.out.InboxRepository.InboxPurposeKey;
 import com.trustamarket.orderservice.order.domain.exception.OrderException;
+import com.trustamarket.orderservice.order.domain.model.OrderId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -52,7 +53,7 @@ public class WalletCancellationCompletedListener {
         try {
             log.info("[WalletCancellationCompleted] consume — eventId={}, orderId={}, cancelledAmount={}",
                     message.eventId(), message.orderId(), message.cancelledAmount());
-            markOrderCancelledUseCase.markCancelled(message.orderId());
+            markOrderCancelledUseCase.markCancelled(OrderId.of(message.orderId()));
             ackAfterCommit(ack);
         } catch (OrderException e) {
             log.warn("[WalletCancellationCompleted] non-retryable, ack + skip — eventId={}, orderId={}",

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/in/messaging/WalletCancellationCompletedListener.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/in/messaging/WalletCancellationCompletedListener.java
@@ -9,6 +9,7 @@ import com.trustamarket.orderservice.order.domain.exception.OrderException;
 import com.trustamarket.orderservice.order.domain.model.OrderId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import com.trustamarket.common.messaging.IdempotentConsumer;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
@@ -29,6 +30,7 @@ public class WalletCancellationCompletedListener {
     private final InboxRepository inboxRepository;
     private final ObjectMapper objectMapper;
 
+    @IdempotentConsumer(CONSUMER_GROUP)
     @KafkaListener(topics = "${trusta.messaging.topic.wallet-cancellation-completed:wallet.cancellation.completed}",
             groupId = CONSUMER_GROUP)
     @Transactional

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/in/messaging/WalletCancellationCompletedListener.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/in/messaging/WalletCancellationCompletedListener.java
@@ -1,0 +1,76 @@
+package com.trustamarket.orderservice.order.adapter.in.messaging;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trustamarket.orderservice.order.adapter.in.messaging.dto.WalletCancellationCompletedMessage;
+import com.trustamarket.orderservice.order.application.port.in.MarkOrderCancelledUseCase;
+import com.trustamarket.orderservice.order.application.port.out.InboxRepository;
+import com.trustamarket.orderservice.order.application.port.out.InboxRepository.InboxPurposeKey;
+import com.trustamarket.orderservice.order.domain.exception.OrderException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+// wallet.cancellation.completed 토픽 consume → CANCELLATION_PROCESSING → CANCELLATION_COMPLETED.
+// 동일 패턴: port 의존, atomic dedup, afterCommit ack, raw JSON 로그 X.
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WalletCancellationCompletedListener {
+
+    private static final String CONSUMER_GROUP = "order-wallet-cancellation-completed-group";
+
+    private final MarkOrderCancelledUseCase markOrderCancelledUseCase;
+    private final InboxRepository inboxRepository;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = "${trusta.messaging.topic.wallet-cancellation-completed:wallet.cancellation.completed}",
+            groupId = CONSUMER_GROUP)
+    @Transactional
+    public void consume(String json, Acknowledgment ack) {
+        WalletCancellationCompletedMessage message;
+        try {
+            message = objectMapper.readValue(json, WalletCancellationCompletedMessage.class);
+        } catch (Exception e) {
+            log.error("[WalletCancellationCompleted] payload 파싱 실패 — ack + skip (length={})",
+                    json == null ? -1 : json.length(), e);
+            ack.acknowledge();
+            return;
+        }
+
+        if (!inboxRepository.tryRecordKafkaEvent(message.eventId(), CONSUMER_GROUP, InboxPurposeKey.WALLET_CANCELLATION_COMPLETED)) {
+            log.info("[WalletCancellationCompleted] 중복 메시지 — ack + skip. eventId={}, orderId={}",
+                    message.eventId(), message.orderId());
+            ack.acknowledge();
+            return;
+        }
+
+        try {
+            log.info("[WalletCancellationCompleted] consume — eventId={}, orderId={}, cancelledAmount={}",
+                    message.eventId(), message.orderId(), message.cancelledAmount());
+            markOrderCancelledUseCase.markCancelled(message.orderId());
+            ackAfterCommit(ack);
+        } catch (OrderException e) {
+            log.warn("[WalletCancellationCompleted] non-retryable, ack + skip — eventId={}, orderId={}",
+                    message.eventId(), message.orderId(), e);
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("[WalletCancellationCompleted] 처리 실패 — eventId={}, orderId={}",
+                    message.eventId(), message.orderId(), e);
+            throw e;
+        }
+    }
+
+    private static void ackAfterCommit(Acknowledgment ack) {
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                ack.acknowledge();
+            }
+        });
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/in/messaging/dto/WalletCancellationCompletedMessage.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/in/messaging/dto/WalletCancellationCompletedMessage.java
@@ -1,0 +1,13 @@
+package com.trustamarket.orderservice.order.adapter.in.messaging.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+// wallet-service 의 `wallet.cancellation.completed` 토픽 페이로드.
+// wallet 이 escrow → buyer 복구 완료 후 발행. order 가 consume → markCancelled.
+public record WalletCancellationCompletedMessage(
+        UUID    eventId,
+        UUID    orderId,
+        long    cancelledAmount,
+        Instant completedAt
+) {}

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/messaging/outbox/OutboxEventListener.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/messaging/outbox/OutboxEventListener.java
@@ -25,9 +25,10 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class OutboxEventListener {
 
-    // eventType 문자열 — ConfirmOrderService 등 발행자와 공유. 신규 추가 시 양쪽 + topic 매핑 함께 변경.
-    public static final String EVENT_SETTLEMENT_REQUESTED = "ORDER.SETTLEMENT_REQUESTED";
-    public static final String EVENT_PRODUCT_SOLD_OUT     = "ORDER.PRODUCT_SOLD_OUT";
+    // eventType 문자열 — 발행자와 공유. 신규 추가 시 양쪽 + topic 매핑 함께 변경.
+    public static final String EVENT_SETTLEMENT_REQUESTED         = "ORDER.SETTLEMENT_REQUESTED";
+    public static final String EVENT_PRODUCT_SOLD_OUT             = "ORDER.PRODUCT_SOLD_OUT";
+    public static final String EVENT_ORDER_CANCELLATION_REQUESTED = "ORDER.CANCELLATION_REQUESTED";
 
     private final OutboxJpaRepository outboxRepository;
     private final ObjectMapper objectMapper;
@@ -36,6 +37,8 @@ public class OutboxEventListener {
     private String settlementTopic;
     @Value("${trusta.messaging.topic.product-sold-out:order.product.sold-out}")
     private String productSoldOutTopic;
+    @Value("${trusta.messaging.topic.order-cancellation-requested:order.cancellation.requested}")
+    private String orderCancellationRequestedTopic;
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onEvent(OutboxEvent event) {
@@ -60,8 +63,9 @@ public class OutboxEventListener {
     // 매핑 누락 시 silent fallback 금지 — 잘못된 토픽 발행 사고를 막기 위해 fail-fast.
     private String resolveTopic(String eventType) {
         return switch (eventType) {
-            case EVENT_SETTLEMENT_REQUESTED -> settlementTopic;
-            case EVENT_PRODUCT_SOLD_OUT     -> productSoldOutTopic;
+            case EVENT_SETTLEMENT_REQUESTED         -> settlementTopic;
+            case EVENT_PRODUCT_SOLD_OUT             -> productSoldOutTopic;
+            case EVENT_ORDER_CANCELLATION_REQUESTED -> orderCancellationRequestedTopic;
             default -> throw new IllegalStateException(
                     "Outbox 토픽 매핑 누락: eventType=" + eventType + ". switch case + application.yaml 토픽 키 추가 필요.");
         };

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/messaging/outbox/OutboxEventListener.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/messaging/outbox/OutboxEventListener.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.trustamarket.common.event.OutboxEvent;
 import com.trustamarket.orderservice.order.adapter.out.persistence.outbox.OutboxJpaEntity;
 import com.trustamarket.orderservice.order.adapter.out.persistence.outbox.OutboxJpaRepository;
+import com.trustamarket.orderservice.order.application.event.messaging.OrderEventTypes;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,11 +25,6 @@ import java.util.UUID;
 @Component
 @RequiredArgsConstructor
 public class OutboxEventListener {
-
-    // eventType 문자열 — 발행자와 공유. 신규 추가 시 양쪽 + topic 매핑 함께 변경.
-    public static final String EVENT_SETTLEMENT_REQUESTED         = "ORDER.SETTLEMENT_REQUESTED";
-    public static final String EVENT_PRODUCT_SOLD_OUT             = "ORDER.PRODUCT_SOLD_OUT";
-    public static final String EVENT_ORDER_CANCELLATION_REQUESTED = "ORDER.CANCELLATION_REQUESTED";
 
     private final OutboxJpaRepository outboxRepository;
     private final ObjectMapper objectMapper;
@@ -63,9 +59,9 @@ public class OutboxEventListener {
     // 매핑 누락 시 silent fallback 금지 — 잘못된 토픽 발행 사고를 막기 위해 fail-fast.
     private String resolveTopic(String eventType) {
         return switch (eventType) {
-            case EVENT_SETTLEMENT_REQUESTED         -> settlementTopic;
-            case EVENT_PRODUCT_SOLD_OUT             -> productSoldOutTopic;
-            case EVENT_ORDER_CANCELLATION_REQUESTED -> orderCancellationRequestedTopic;
+            case OrderEventTypes.SETTLEMENT_REQUESTED         -> settlementTopic;
+            case OrderEventTypes.PRODUCT_SOLD_OUT             -> productSoldOutTopic;
+            case OrderEventTypes.ORDER_CANCELLATION_REQUESTED -> orderCancellationRequestedTopic;
             default -> throw new IllegalStateException(
                     "Outbox 토픽 매핑 누락: eventType=" + eventType + ". switch case + application.yaml 토픽 키 추가 필요.");
         };

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/inbox/InboxJpaAdapter.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/inbox/InboxJpaAdapter.java
@@ -52,9 +52,10 @@ public class InboxJpaAdapter implements InboxRepository {
 
     private static InboxPurpose toJpaPurpose(InboxPurposeKey key) {
         return switch (key) {
-            case REQUEST_PAYMENT     -> InboxPurpose.REQUEST_PAYMENT;
-            case DELIVERY_STARTED    -> InboxPurpose.DELIVERY_STARTED;
-            case DELIVERY_COMPLETED  -> InboxPurpose.DELIVERY_COMPLETED;
+            case REQUEST_PAYMENT                -> InboxPurpose.REQUEST_PAYMENT;
+            case DELIVERY_STARTED               -> InboxPurpose.DELIVERY_STARTED;
+            case DELIVERY_COMPLETED             -> InboxPurpose.DELIVERY_COMPLETED;
+            case WALLET_CANCELLATION_COMPLETED  -> InboxPurpose.WALLET_CANCELLATION_COMPLETED;
         };
     }
 }

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/inbox/InboxPurpose.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/inbox/InboxPurpose.java
@@ -2,7 +2,8 @@ package com.trustamarket.orderservice.order.adapter.out.persistence.inbox;
 
 // inbox row 가 어떤 흐름의 멱등성 기록인지.
 public enum InboxPurpose {
-    REQUEST_PAYMENT,        // POST /payments 외부 호출 멱등성 (Idempotency-Key)
-    DELIVERY_STARTED,       // delivery.started Kafka 메시지 멱등성
-    DELIVERY_COMPLETED      // delivery.completed Kafka 메시지 멱등성
+    REQUEST_PAYMENT,                // POST /payments 외부 호출 멱등성 (Idempotency-Key)
+    DELIVERY_STARTED,               // delivery.started Kafka 메시지 멱등성
+    DELIVERY_COMPLETED,             // delivery.completed Kafka 메시지 멱등성
+    WALLET_CANCELLATION_COMPLETED   // wallet.cancellation.completed Kafka 메시지 멱등성
 }

--- a/src/main/java/com/trustamarket/orderservice/order/application/event/messaging/OrderCancellationRequestedMessage.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/event/messaging/OrderCancellationRequestedMessage.java
@@ -1,0 +1,20 @@
+package com.trustamarket.orderservice.order.application.event.messaging;
+
+import java.time.Instant;
+import java.util.UUID;
+
+// wallet-service 의 `order.cancellation.requested` 토픽 페이로드 — 양 팀 합의 스키마.
+// wallet 측은 escrow 차감 + buyer 지갑 복구 후 wallet.cancellation.completed 응답.
+public record OrderCancellationRequestedMessage(
+        UUID    eventId,           // 멱등성 키
+        UUID    orderId,
+        UUID    buyerId,
+        long    cancelledAmount,
+        Instant cancelledAt
+) {
+    public static OrderCancellationRequestedMessage of(
+            UUID orderId, UUID buyerId, long cancelledAmount, Instant cancelledAt) {
+        return new OrderCancellationRequestedMessage(
+                UUID.randomUUID(), orderId, buyerId, cancelledAmount, cancelledAt);
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/application/event/messaging/OrderEventTypes.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/event/messaging/OrderEventTypes.java
@@ -1,0 +1,13 @@
+package com.trustamarket.orderservice.order.application.event.messaging;
+
+// order 도메인이 발행하는 OutboxEvent 의 eventType 문자열 상수.
+// application 과 adapter 양쪽이 본 클래스만 의존 — adapter 직접 참조 회피 (헥사고날 경계 보존).
+// 신규 이벤트 추가 시 여기 + adapter/out/messaging/outbox/OutboxEventListener 의 topic 매핑 + application.yaml 토픽 키 함께 갱신.
+public final class OrderEventTypes {
+
+    public static final String SETTLEMENT_REQUESTED         = "ORDER.SETTLEMENT_REQUESTED";
+    public static final String PRODUCT_SOLD_OUT             = "ORDER.PRODUCT_SOLD_OUT";
+    public static final String ORDER_CANCELLATION_REQUESTED = "ORDER.CANCELLATION_REQUESTED";
+
+    private OrderEventTypes() {}
+}

--- a/src/main/java/com/trustamarket/orderservice/order/application/port/in/CancelOrderUseCase.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/port/in/CancelOrderUseCase.java
@@ -6,8 +6,8 @@ import com.trustamarket.orderservice.order.domain.exception.InvalidReasonExcepti
 import java.util.UUID;
 
 // 주문 취소 — POST /api/orders/{id}/cancellations
-// REQUESTED/PAYMENT_PENDING → CANCELLED, PAID → REFUND_PROCESSING
-// markRefunded(환불 완료 처리)는 MVP scope 외 (TODO)
+// REQUESTED/PAYMENT_PENDING → CANCELLED, PAID → CANCELLATION_PROCESSING
+// CANCELLATION_PROCESSING → CANCELLATION_COMPLETED 는 MarkOrderCancelledUseCase 가 처리.
 public interface CancelOrderUseCase {
 
     void cancel(CancelOrderCommand command);

--- a/src/main/java/com/trustamarket/orderservice/order/application/port/in/MarkOrderCancelledUseCase.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/port/in/MarkOrderCancelledUseCase.java
@@ -1,0 +1,9 @@
+package com.trustamarket.orderservice.order.application.port.in;
+
+import java.util.UUID;
+
+// CANCELLATION_PROCESSING → CANCELLATION_COMPLETED.
+// wallet.cancellation.completed Kafka 이벤트가 트리거.
+public interface MarkOrderCancelledUseCase {
+    void markCancelled(UUID orderId);
+}

--- a/src/main/java/com/trustamarket/orderservice/order/application/port/in/MarkOrderCancelledUseCase.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/port/in/MarkOrderCancelledUseCase.java
@@ -1,9 +1,9 @@
 package com.trustamarket.orderservice.order.application.port.in;
 
-import java.util.UUID;
+import com.trustamarket.orderservice.order.domain.model.OrderId;
 
 // CANCELLATION_PROCESSING → CANCELLATION_COMPLETED.
 // wallet.cancellation.completed Kafka 이벤트가 트리거.
 public interface MarkOrderCancelledUseCase {
-    void markCancelled(UUID orderId);
+    void markCancelled(OrderId orderId);
 }

--- a/src/main/java/com/trustamarket/orderservice/order/application/port/out/InboxRepository.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/port/out/InboxRepository.java
@@ -22,6 +22,7 @@ public interface InboxRepository {
     enum InboxPurposeKey {
         REQUEST_PAYMENT,
         DELIVERY_STARTED,
-        DELIVERY_COMPLETED
+        DELIVERY_COMPLETED,
+        WALLET_CANCELLATION_COMPLETED
     }
 }

--- a/src/main/java/com/trustamarket/orderservice/order/application/port/out/WalletPaymentPort.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/port/out/WalletPaymentPort.java
@@ -12,7 +12,7 @@ public interface WalletPaymentPort {
 
     // 주문 결제 시점에 포인트 차감 요청
     DeductPointResponse deduct(DeductPointRequest request);
-    // TODO: 환불 흐름은 MVP scope 외 — 추후 별도 PR에서 추가 (sync vs 이벤트 결정 포함)
+    // 취소 흐름은 sync 호출이 아닌 Kafka (order.cancellation.requested) 로 진행 — 본 port 와 무관.
 
     // 주문 -> 포인트 사용 요청 DTO
     // 금액은 룰 [3]에 따라 long(원시형) 사용. compact constructor로 입력 검증

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/command/CancelOrderService.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/command/CancelOrderService.java
@@ -1,5 +1,9 @@
 package com.trustamarket.orderservice.order.application.service.command;
 
+import com.trustamarket.common.event.Events;
+import com.trustamarket.common.event.OutboxEvent;
+import com.trustamarket.orderservice.order.adapter.out.messaging.outbox.OutboxEventListener;
+import com.trustamarket.orderservice.order.application.event.messaging.OrderCancellationRequestedMessage;
 import com.trustamarket.orderservice.order.application.port.in.CancelOrderUseCase;
 import com.trustamarket.orderservice.order.application.port.out.OrderRepository;
 import com.trustamarket.orderservice.order.application.service.support.OrderAccessGuard;
@@ -12,11 +16,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-// REQUESTED/PAYMENT_PENDING → CANCELLED, PAID → REFUND_PROCESSING
-// markRefunded(환불 완료) 호출은 MVP scope 외 (Wallet 환불 호출 + 이벤트는 후속 PR)
+import java.time.Instant;
+
+// 결제 전: REQUESTED / PAYMENT_PENDING → CANCELLED (wallet 무관)
+// 결제 후 (PAID): CANCELLATION_PROCESSING + Outbox publish → wallet escrow 복구 후
+//                wallet.cancellation.completed 수신 → MarkOrderCancelledService 가 CANCELLATION_COMPLETED 마킹
 @Service
 @RequiredArgsConstructor
 public class CancelOrderService implements CancelOrderUseCase {
+
+    private static final String DOMAIN_TYPE = "ORDER";
 
     private final OrderRepository orderRepository;
     private final OrderHistoryRecorder historyRecorder;
@@ -34,7 +43,16 @@ public class CancelOrderService implements CancelOrderUseCase {
 
         orderRepository.save(order);
 
-        // TODO: 다음 PR — PAID 이전이었으면 OrderCancelledEvent 발행 (Wallet 환불 트리거)
-        //       지금 흐름: REFUND_PROCESSING 상태로 두고 markRefunded는 후속 PR에서 호출
+        // 결제 후 취소만 wallet 통신 필요 — 결제 전 취소는 wallet 차감 없으니 publish X.
+        if (pre == OrderStatus.PAID) {
+            Events.trigger(OutboxEvent.of(
+                    DOMAIN_TYPE, order.getId().value(),
+                    OutboxEventListener.EVENT_ORDER_CANCELLATION_REQUESTED,
+                    OrderCancellationRequestedMessage.of(
+                            order.getId().value(),
+                            order.getBuyer().id(),
+                            order.getTotalAmount().value(),
+                            Instant.now())));
+        }
     }
 }

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/command/CancelOrderService.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/command/CancelOrderService.java
@@ -2,7 +2,7 @@ package com.trustamarket.orderservice.order.application.service.command;
 
 import com.trustamarket.common.event.Events;
 import com.trustamarket.common.event.OutboxEvent;
-import com.trustamarket.orderservice.order.adapter.out.messaging.outbox.OutboxEventListener;
+import com.trustamarket.orderservice.order.application.event.messaging.OrderEventTypes;
 import com.trustamarket.orderservice.order.application.event.messaging.OrderCancellationRequestedMessage;
 import com.trustamarket.orderservice.order.application.port.in.CancelOrderUseCase;
 import com.trustamarket.orderservice.order.application.port.out.OrderRepository;
@@ -47,7 +47,7 @@ public class CancelOrderService implements CancelOrderUseCase {
         if (pre == OrderStatus.PAID) {
             Events.trigger(OutboxEvent.of(
                     DOMAIN_TYPE, order.getId().value(),
-                    OutboxEventListener.EVENT_ORDER_CANCELLATION_REQUESTED,
+                    OrderEventTypes.ORDER_CANCELLATION_REQUESTED,
                     OrderCancellationRequestedMessage.of(
                             order.getId().value(),
                             order.getBuyer().id(),

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/command/ConfirmOrderService.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/command/ConfirmOrderService.java
@@ -2,7 +2,7 @@ package com.trustamarket.orderservice.order.application.service.command;
 
 import com.trustamarket.common.event.Events;
 import com.trustamarket.common.event.OutboxEvent;
-import com.trustamarket.orderservice.order.adapter.out.messaging.outbox.OutboxEventListener;
+import com.trustamarket.orderservice.order.application.event.messaging.OrderEventTypes;
 import com.trustamarket.orderservice.order.application.event.messaging.ProductSoldOutMessage;
 import com.trustamarket.orderservice.order.application.event.messaging.SettlePointSettlementMessage;
 import com.trustamarket.orderservice.order.application.port.in.ConfirmOrderUseCase;
@@ -48,7 +48,7 @@ public class ConfirmOrderService implements ConfirmOrderUseCase {
         // 메시지 record 는 application/event/messaging/ — adapter 의존 차단을 위해 primitive factory 사용.
         Events.trigger(OutboxEvent.of(
                 DOMAIN_TYPE, order.getId().value(),
-                OutboxEventListener.EVENT_SETTLEMENT_REQUESTED,
+                OrderEventTypes.SETTLEMENT_REQUESTED,
                 SettlePointSettlementMessage.of(
                         order.getId().value(),
                         order.getBuyer().id(),
@@ -62,7 +62,7 @@ public class ConfirmOrderService implements ConfirmOrderUseCase {
 
         Events.trigger(OutboxEvent.of(
                 DOMAIN_TYPE, order.getId().value(),
-                OutboxEventListener.EVENT_PRODUCT_SOLD_OUT,
+                OrderEventTypes.PRODUCT_SOLD_OUT,
                 ProductSoldOutMessage.of(
                         order.getId().value(),
                         order.getProduct().id(),

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/command/MarkOrderCancelledService.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/command/MarkOrderCancelledService.java
@@ -10,8 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.UUID;
-
 @Service
 @RequiredArgsConstructor
 public class MarkOrderCancelledService implements MarkOrderCancelledUseCase {
@@ -21,8 +19,8 @@ public class MarkOrderCancelledService implements MarkOrderCancelledUseCase {
 
     @Override
     @Transactional
-    public void markCancelled(UUID orderId) {
-        Order order = orderRepository.findByIdOrThrow(OrderId.of(orderId));
+    public void markCancelled(OrderId orderId) {
+        Order order = orderRepository.findByIdOrThrow(orderId);
         OrderStatus pre = order.getStatus();
         order.markCancelled();
         historyRecorder.record(order.getId(), pre, order.getStatus(), null);

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/command/MarkOrderCancelledService.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/command/MarkOrderCancelledService.java
@@ -1,0 +1,31 @@
+package com.trustamarket.orderservice.order.application.service.command;
+
+import com.trustamarket.orderservice.order.application.port.in.MarkOrderCancelledUseCase;
+import com.trustamarket.orderservice.order.application.port.out.OrderRepository;
+import com.trustamarket.orderservice.order.application.service.support.OrderHistoryRecorder;
+import com.trustamarket.orderservice.order.domain.model.Order;
+import com.trustamarket.orderservice.order.domain.model.OrderId;
+import com.trustamarket.orderservice.order.domain.model.OrderStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class MarkOrderCancelledService implements MarkOrderCancelledUseCase {
+
+    private final OrderRepository orderRepository;
+    private final OrderHistoryRecorder historyRecorder;
+
+    @Override
+    @Transactional
+    public void markCancelled(UUID orderId) {
+        Order order = orderRepository.findByIdOrThrow(OrderId.of(orderId));
+        OrderStatus pre = order.getStatus();
+        order.markCancelled();
+        historyRecorder.record(order.getId(), pre, order.getStatus(), null);
+        orderRepository.save(order);
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/Order.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/Order.java
@@ -195,10 +195,10 @@ public class Order {
             throw RestoreStateMismatchException.missingConfirmedAt(status);
         }
 
-        // 취소/환불 상태는 cancelReason 필수
+        // 취소 관련 상태는 cancelReason 필수
         if ((status == OrderStatus.CANCELLED
-                || status == OrderStatus.REFUND_PROCESSING
-                || status == OrderStatus.REFUND_COMPLETED)
+                || status == OrderStatus.CANCELLATION_PROCESSING
+                || status == OrderStatus.CANCELLATION_COMPLETED)
                 && cancelReason == null) {
             throw RestoreStateMismatchException.missingCancelReason(status);
         }
@@ -275,11 +275,11 @@ public class Order {
     }
 
 
-    // 행위 메서드 — 취소 / 환불
+    // 행위 메서드 — 취소
 
-    // 취소 (배송 시작 전 단계만 허용 — REQUESTED/PAYMENT_PENDING → CANCELLED, PAID → REFUND_PROCESSING)
-    // OrderTransition 표가 잘못된 상태 조합을 자동 차단 (CancelNotAllowedException은 application 레이어에서 사전 검증 시 사용)
-    // OrderCancelledEvent를 application/adapter 레이어에서 발행 (Wallet 환불 트리거)
+    // 취소 (배송 시작 전까지만 허용 — REQUESTED/PAYMENT_PENDING → CANCELLED, PAID → CANCELLATION_PROCESSING)
+    // OrderTransition 표가 잘못된 상태 조합을 자동 차단 (CancelNotAllowedException 은 application 레이어 사전 검증용)
+    // PAID 분기에서는 application 이 후속으로 order.cancellation.requested Outbox 발행 → wallet escrow 복구.
     public void cancel(Reason reason) {
         if (reason == null) {
             throw new InvalidReasonException();
@@ -288,10 +288,10 @@ public class Order {
         this.cancelReason = reason;
     }
 
-    // REFUND_PROCESSING → REFUND_COMPLETED
-    // Wallet의 RefundCompleted 이벤트 수신 시
-    public void markRefunded() {
-        this.status = OrderTransition.apply(this.status, OrderAction.MARK_REFUNDED);
+    // CANCELLATION_PROCESSING → CANCELLATION_COMPLETED.
+    // wallet.cancellation.completed 수신 시 호출 (escrow → buyer 복구 끝났다는 신호).
+    public void markCancelled() {
+        this.status = OrderTransition.apply(this.status, OrderAction.MARK_CANCELLED);
     }
 
 

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderAction.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderAction.java
@@ -1,6 +1,6 @@
 package com.trustamarket.orderservice.order.domain.model;
 
-// Order 상태 머신의 액션(동작) (OrderTransition이 사용)
+// Order 상태 머신의 액션 (OrderTransition 이 사용)
 public enum OrderAction {
 
     REQUEST_PAYMENT,      // REQUESTED → PAYMENT_PENDING
@@ -9,8 +9,8 @@ public enum OrderAction {
     MARK_DELIVERED,       // SHIPPING → DELIVERED
     CONFIRM,              // DELIVERED → CONFIRMED (거래 종결)
 
-    CANCEL,               // (배송 시작 전) → CANCELLED 또는 REFUND_PROCESSING
-    MARK_REFUNDED,        // REFUND_PROCESSING → REFUND_COMPLETED (Wallet RefundCompleted 수신)
+    CANCEL,               // (결제 전) → CANCELLED, (PAID) → CANCELLATION_PROCESSING
+    MARK_CANCELLED,       // CANCELLATION_PROCESSING → CANCELLATION_COMPLETED (wallet.cancellation.completed 수신)
 
     REQUEST_RETURN,       // (배송 시작 후) → RETURN_REQUESTED
     APPROVE_RETURN,       // RETURN_REQUESTED → RETURN_APPROVED

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderReturnStatus.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderReturnStatus.java
@@ -9,5 +9,5 @@ public enum OrderReturnStatus {
     RETURN_COLLECTING,    // 구매자 → 센터 반송 배송 중
     RETURN_RECEIVED,      // 센터 도착
     RETURN_INSPECTING,    // 재검수 중
-    RETURN_COMPLETED      // 반송 완료 (이후 환불 흐름)
+    RETURN_COMPLETED      // 반송 완료 (이후 취소 흐름은 별도 PR)
 }

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderStatus.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderStatus.java
@@ -2,24 +2,24 @@ package com.trustamarket.orderservice.order.domain.model;
 
 public enum OrderStatus {
 
-    REQUESTED,             // 주문 생성됨
-    PAYMENT_PENDING,       // 결제 시작 (Wallet 차감 대기)
-    PAID,                  // 결제 완료 (Wallet holding 보관)
-    SHIPPING,              // 배송 중
-    DELIVERED,             // 배송 완료
-    CONFIRMED,             // 구매 확정 — 거래 종결 (정산 흐름은 추후 별도 PR에서 도입)
-    CANCELLED,             // 결제 전 취소
-    REFUND_PROCESSING,     // 결제 후 취소, 환불 처리 중
-    REFUND_COMPLETED,      // 환불 완료
-    RETURN_REQUESTED,      // 반송 요청 (배송 시작 후만 가능)
-    RETURN_APPROVED,       // 반송 승인 (이후 OrderReturnStatus가 추적)
-    RETURN_REJECTED;       // 반송 거절
+    REQUESTED,                  // 주문 생성됨
+    PAYMENT_PENDING,            // 결제 시작 (Wallet 차감 대기)
+    PAID,                       // 결제 완료 (Wallet escrow 보관)
+    SHIPPING,                   // 배송 중
+    DELIVERED,                  // 배송 완료
+    CONFIRMED,                  // 구매 확정 — 거래 종결 (정산 트리거)
+    CANCELLED,                  // 결제 전 취소 (wallet 차감 안 됨)
+    CANCELLATION_PROCESSING,    // 결제 후 취소 — wallet escrow 복구 대기
+    CANCELLATION_COMPLETED,     // 결제 후 취소 완료 — escrow 복구 끝
+    RETURN_REQUESTED,           // 반송 요청 (배송 시작 후만 가능)
+    RETURN_APPROVED,            // 반송 승인
+    RETURN_REJECTED;            // 반송 거절
 
     // 종결 상태 — 더 이상 OrderTransition 표에 out-going 전이 없음
     public boolean isTerminal() {
         return this == CONFIRMED
                 || this == CANCELLED
-                || this == REFUND_COMPLETED
+                || this == CANCELLATION_COMPLETED
                 || this == RETURN_REJECTED
                 || this == RETURN_APPROVED;
     }

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderTransition.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderTransition.java
@@ -9,7 +9,7 @@ import static com.trustamarket.orderservice.order.domain.model.OrderAction.CANCE
 import static com.trustamarket.orderservice.order.domain.model.OrderAction.CONFIRM;
 import static com.trustamarket.orderservice.order.domain.model.OrderAction.MARK_DELIVERED;
 import static com.trustamarket.orderservice.order.domain.model.OrderAction.MARK_PAID;
-import static com.trustamarket.orderservice.order.domain.model.OrderAction.MARK_REFUNDED;
+import static com.trustamarket.orderservice.order.domain.model.OrderAction.MARK_CANCELLED;
 import static com.trustamarket.orderservice.order.domain.model.OrderAction.REJECT_RETURN;
 import static com.trustamarket.orderservice.order.domain.model.OrderAction.REQUEST_PAYMENT;
 import static com.trustamarket.orderservice.order.domain.model.OrderAction.REQUEST_RETURN;
@@ -19,8 +19,8 @@ import static com.trustamarket.orderservice.order.domain.model.OrderStatus.CONFI
 import static com.trustamarket.orderservice.order.domain.model.OrderStatus.DELIVERED;
 import static com.trustamarket.orderservice.order.domain.model.OrderStatus.PAID;
 import static com.trustamarket.orderservice.order.domain.model.OrderStatus.PAYMENT_PENDING;
-import static com.trustamarket.orderservice.order.domain.model.OrderStatus.REFUND_COMPLETED;
-import static com.trustamarket.orderservice.order.domain.model.OrderStatus.REFUND_PROCESSING;
+import static com.trustamarket.orderservice.order.domain.model.OrderStatus.CANCELLATION_COMPLETED;
+import static com.trustamarket.orderservice.order.domain.model.OrderStatus.CANCELLATION_PROCESSING;
 import static com.trustamarket.orderservice.order.domain.model.OrderStatus.REQUESTED;
 import static com.trustamarket.orderservice.order.domain.model.OrderStatus.RETURN_APPROVED;
 import static com.trustamarket.orderservice.order.domain.model.OrderStatus.RETURN_REJECTED;
@@ -48,10 +48,10 @@ public final class OrderTransition {
             // 취소 분기 (배송 시작 전까지만)
             Map.entry(new Key(REQUESTED,             CANCEL),           CANCELLED),
             Map.entry(new Key(PAYMENT_PENDING,       CANCEL),           CANCELLED),
-            Map.entry(new Key(PAID,                  CANCEL),           REFUND_PROCESSING),
+            Map.entry(new Key(PAID,                  CANCEL),           CANCELLATION_PROCESSING),
 
-            // 환불 완료 (Wallet RefundCompleted 수신)
-            Map.entry(new Key(REFUND_PROCESSING,     MARK_REFUNDED),    REFUND_COMPLETED),
+            // 결제 후 취소 완료 (wallet.cancellation.completed 수신)
+            Map.entry(new Key(CANCELLATION_PROCESSING,     MARK_CANCELLED),    CANCELLATION_COMPLETED),
 
             // 반송 분기 (배송 시작 후만)
             Map.entry(new Key(SHIPPING,              REQUEST_RETURN),   RETURN_REQUESTED),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -34,7 +34,9 @@ spring:
 trusta:
   messaging:
     topic:
-      settlement-requested: order.wallet-settlement.requested
-      product-sold-out:    order.product.sold-out
-      delivery-started:    delivery.started
-      delivery-completed:  delivery.completed
+      settlement-requested:           order.wallet-settlement.requested
+      product-sold-out:               order.product.sold-out
+      delivery-started:               delivery.started
+      delivery-completed:             delivery.completed
+      order-cancellation-requested:   order.cancellation.requested
+      wallet-cancellation-completed:  wallet.cancellation.completed

--- a/src/main/resources/db/changelog/006-rename-order-status-refund-to-cancellation.yaml
+++ b/src/main/resources/db/changelog/006-rename-order-status-refund-to-cancellation.yaml
@@ -3,32 +3,19 @@ databaseChangeLog:
       id: 006-rename-order-status-refund-to-cancellation
       author: lhk
       changes:
-        # 기존 row 의 enum 값 일괄 UPDATE — 운영 데이터가 있어도 안전.
+        # p_order — 현재 상태 컬럼은 도메인 명명 변경에 맞춰 갱신 필요 (도메인 코드와 enum 값 일관성).
         - sql:
             sql: "UPDATE p_order SET status = 'CANCELLATION_PROCESSING' WHERE status = 'REFUND_PROCESSING'"
         - sql:
             sql: "UPDATE p_order SET status = 'CANCELLATION_COMPLETED'  WHERE status = 'REFUND_COMPLETED'"
 
-        # status_history 의 prev_status / next_status 도 동일 변환.
-        - sql:
-            sql: "UPDATE p_order_status_history SET prev_status = 'CANCELLATION_PROCESSING' WHERE prev_status = 'REFUND_PROCESSING'"
-        - sql:
-            sql: "UPDATE p_order_status_history SET prev_status = 'CANCELLATION_COMPLETED'  WHERE prev_status = 'REFUND_COMPLETED'"
-        - sql:
-            sql: "UPDATE p_order_status_history SET next_status = 'CANCELLATION_PROCESSING' WHERE next_status = 'REFUND_PROCESSING'"
-        - sql:
-            sql: "UPDATE p_order_status_history SET next_status = 'CANCELLATION_COMPLETED'  WHERE next_status = 'REFUND_COMPLETED'"
+        # p_order_status_history 는 append-only 정책이라 본 changeSet 에서 UPDATE 하지 않음.
+        # 옛 enum 값 (REFUND_*) 가 그대로 보존되어 그 시점 진실을 기록.
+        # OrderStatus 코드에는 새 enum 값만 있어서 history 조회 시 옛 값을 읽으면 매핑 실패하므로,
+        # 조회 측은 "REFUND_*" 문자열을 직접 비교 가능한 read-side 처리로 대응 (별도 후속).
 
       rollback:
         - sql:
             sql: "UPDATE p_order SET status = 'REFUND_PROCESSING' WHERE status = 'CANCELLATION_PROCESSING'"
         - sql:
             sql: "UPDATE p_order SET status = 'REFUND_COMPLETED'  WHERE status = 'CANCELLATION_COMPLETED'"
-        - sql:
-            sql: "UPDATE p_order_status_history SET prev_status = 'REFUND_PROCESSING' WHERE prev_status = 'CANCELLATION_PROCESSING'"
-        - sql:
-            sql: "UPDATE p_order_status_history SET prev_status = 'REFUND_COMPLETED'  WHERE prev_status = 'CANCELLATION_COMPLETED'"
-        - sql:
-            sql: "UPDATE p_order_status_history SET next_status = 'REFUND_PROCESSING' WHERE next_status = 'CANCELLATION_PROCESSING'"
-        - sql:
-            sql: "UPDATE p_order_status_history SET next_status = 'REFUND_COMPLETED'  WHERE next_status = 'CANCELLATION_COMPLETED'"

--- a/src/main/resources/db/changelog/006-rename-order-status-refund-to-cancellation.yaml
+++ b/src/main/resources/db/changelog/006-rename-order-status-refund-to-cancellation.yaml
@@ -1,0 +1,34 @@
+databaseChangeLog:
+  - changeSet:
+      id: 006-rename-order-status-refund-to-cancellation
+      author: lhk
+      changes:
+        # 기존 row 의 enum 값 일괄 UPDATE — 운영 데이터가 있어도 안전.
+        - sql:
+            sql: "UPDATE p_order SET status = 'CANCELLATION_PROCESSING' WHERE status = 'REFUND_PROCESSING'"
+        - sql:
+            sql: "UPDATE p_order SET status = 'CANCELLATION_COMPLETED'  WHERE status = 'REFUND_COMPLETED'"
+
+        # status_history 의 prev_status / next_status 도 동일 변환.
+        - sql:
+            sql: "UPDATE p_order_status_history SET prev_status = 'CANCELLATION_PROCESSING' WHERE prev_status = 'REFUND_PROCESSING'"
+        - sql:
+            sql: "UPDATE p_order_status_history SET prev_status = 'CANCELLATION_COMPLETED'  WHERE prev_status = 'REFUND_COMPLETED'"
+        - sql:
+            sql: "UPDATE p_order_status_history SET next_status = 'CANCELLATION_PROCESSING' WHERE next_status = 'REFUND_PROCESSING'"
+        - sql:
+            sql: "UPDATE p_order_status_history SET next_status = 'CANCELLATION_COMPLETED'  WHERE next_status = 'REFUND_COMPLETED'"
+
+      rollback:
+        - sql:
+            sql: "UPDATE p_order SET status = 'REFUND_PROCESSING' WHERE status = 'CANCELLATION_PROCESSING'"
+        - sql:
+            sql: "UPDATE p_order SET status = 'REFUND_COMPLETED'  WHERE status = 'CANCELLATION_COMPLETED'"
+        - sql:
+            sql: "UPDATE p_order_status_history SET prev_status = 'REFUND_PROCESSING' WHERE prev_status = 'CANCELLATION_PROCESSING'"
+        - sql:
+            sql: "UPDATE p_order_status_history SET prev_status = 'REFUND_COMPLETED'  WHERE prev_status = 'CANCELLATION_COMPLETED'"
+        - sql:
+            sql: "UPDATE p_order_status_history SET next_status = 'REFUND_PROCESSING' WHERE next_status = 'CANCELLATION_PROCESSING'"
+        - sql:
+            sql: "UPDATE p_order_status_history SET next_status = 'REFUND_COMPLETED'  WHERE next_status = 'CANCELLATION_COMPLETED'"

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -9,3 +9,5 @@ databaseChangeLog:
       file: db/changelog/004-create-p-order-inbox.yaml
   - include:
       file: db/changelog/005-alter-p-order-inbox-composite-unique.yaml
+  - include:
+      file: db/changelog/006-rename-order-status-refund-to-cancellation.yaml

--- a/src/test/java/com/trustamarket/orderservice/order/application/service/command/CancelOrderServiceTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/application/service/command/CancelOrderServiceTest.java
@@ -1,5 +1,9 @@
 package com.trustamarket.orderservice.order.application.service.command;
 
+import com.trustamarket.common.event.Events;
+import com.trustamarket.common.event.OutboxEvent;
+import com.trustamarket.orderservice.order.application.event.messaging.OrderCancellationRequestedMessage;
+import com.trustamarket.orderservice.order.application.event.messaging.OrderEventTypes;
 import com.trustamarket.orderservice.order.application.exception.UnauthorizedOrderAccessException;
 import com.trustamarket.orderservice.order.application.port.in.CancelOrderUseCase.CancelOrderCommand;
 import com.trustamarket.orderservice.order.application.port.out.OrderRepository;
@@ -11,7 +15,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.MockedStatic;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.UUID;
@@ -19,6 +25,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -45,17 +52,42 @@ class CancelOrderServiceTest {
     }
 
     @Test
-    @DisplayName("PAID 단계 취소 → CANCELLATION_PROCESSING (markCancelled는 후속 PR)")
+    @DisplayName("PAID 단계 취소 → CANCELLATION_PROCESSING + Outbox 발행")
     void cancelPaid() {
         UUID buyerId = UUID.randomUUID();
         Order order = OrderTestFixtures.paidOrder(buyerId, UUID.randomUUID());
         when(orderRepository.findByIdOrThrow(order.getId())).thenReturn(order);
 
-        service.cancel(new CancelOrderCommand(order.getId().value(), buyerId, "환불 요청"));
+        try (MockedStatic<Events> mocked = Mockito.mockStatic(Events.class)) {
+            service.cancel(new CancelOrderCommand(order.getId().value(), buyerId, "단순 변심"));
 
-        assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLATION_PROCESSING);
-        verify(historyRecorder).record(order.getId(), OrderStatus.PAID, OrderStatus.CANCELLATION_PROCESSING, order.getCancelReason());
-        verify(orderRepository).save(order);
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLATION_PROCESSING);
+            verify(historyRecorder).record(order.getId(), OrderStatus.PAID, OrderStatus.CANCELLATION_PROCESSING, order.getCancelReason());
+            verify(orderRepository).save(order);
+
+            // PAID 분기에서만 Outbox publish — eventType + payload 검증.
+            mocked.verify(() -> Events.trigger(argThat((OutboxEvent e) ->
+                    OrderEventTypes.ORDER_CANCELLATION_REQUESTED.equals(e.eventType())
+                            && e.payload() instanceof OrderCancellationRequestedMessage m
+                            && m.orderId().equals(order.getId().value())
+                            && m.buyerId().equals(buyerId)
+                            && m.cancelledAmount() == order.getTotalAmount().value()
+            )));
+        }
+    }
+
+    @Test
+    @DisplayName("REQUESTED 단계 취소 → Outbox 발행 X (wallet 차감 전이라 복구 불필요)")
+    void cancelRequested_noOutbox() {
+        UUID buyerId = UUID.randomUUID();
+        Order order = OrderTestFixtures.requestedOrder(buyerId, UUID.randomUUID());
+        when(orderRepository.findByIdOrThrow(order.getId())).thenReturn(order);
+
+        try (MockedStatic<Events> mocked = Mockito.mockStatic(Events.class)) {
+            service.cancel(new CancelOrderCommand(order.getId().value(), buyerId, "변심"));
+
+            mocked.verifyNoInteractions();
+        }
     }
 
     @Test

--- a/src/test/java/com/trustamarket/orderservice/order/application/service/command/CancelOrderServiceTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/application/service/command/CancelOrderServiceTest.java
@@ -45,7 +45,7 @@ class CancelOrderServiceTest {
     }
 
     @Test
-    @DisplayName("PAID 단계 취소 → REFUND_PROCESSING (markRefunded는 후속 PR)")
+    @DisplayName("PAID 단계 취소 → CANCELLATION_PROCESSING (markCancelled는 후속 PR)")
     void cancelPaid() {
         UUID buyerId = UUID.randomUUID();
         Order order = OrderTestFixtures.paidOrder(buyerId, UUID.randomUUID());
@@ -53,8 +53,8 @@ class CancelOrderServiceTest {
 
         service.cancel(new CancelOrderCommand(order.getId().value(), buyerId, "환불 요청"));
 
-        assertThat(order.getStatus()).isEqualTo(OrderStatus.REFUND_PROCESSING);
-        verify(historyRecorder).record(order.getId(), OrderStatus.PAID, OrderStatus.REFUND_PROCESSING, order.getCancelReason());
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLATION_PROCESSING);
+        verify(historyRecorder).record(order.getId(), OrderStatus.PAID, OrderStatus.CANCELLATION_PROCESSING, order.getCancelReason());
         verify(orderRepository).save(order);
     }
 

--- a/src/test/java/com/trustamarket/orderservice/order/application/service/command/MarkOrderCancelledServiceTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/application/service/command/MarkOrderCancelledServiceTest.java
@@ -3,7 +3,10 @@ package com.trustamarket.orderservice.order.application.service.command;
 import com.trustamarket.orderservice.order.application.port.out.OrderRepository;
 import com.trustamarket.orderservice.order.application.service.OrderTestFixtures;
 import com.trustamarket.orderservice.order.application.service.support.OrderHistoryRecorder;
+import com.trustamarket.orderservice.order.domain.exception.InvalidStatusTransitionException;
+import com.trustamarket.orderservice.order.domain.exception.OrderNotFoundException;
 import com.trustamarket.orderservice.order.domain.model.Order;
+import com.trustamarket.orderservice.order.domain.model.OrderId;
 import com.trustamarket.orderservice.order.domain.model.OrderStatus;
 import com.trustamarket.orderservice.order.domain.model.Reason;
 import org.junit.jupiter.api.DisplayName;
@@ -16,6 +19,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -40,5 +46,35 @@ class MarkOrderCancelledServiceTest {
         verify(historyRecorder).record(order.getId(),
                 OrderStatus.CANCELLATION_PROCESSING, OrderStatus.CANCELLATION_COMPLETED, null);
         verify(orderRepository).save(order);
+    }
+
+    @Test
+    @DisplayName("Order 없음 → OrderNotFoundException + 부수효과 X")
+    void orderNotFound() {
+        UUID orderId = UUID.randomUUID();
+        when(orderRepository.findByIdOrThrow(OrderId.of(orderId)))
+                .thenThrow(new OrderNotFoundException(orderId));
+
+        assertThatThrownBy(() -> service.markCancelled(orderId))
+                .isInstanceOf(OrderNotFoundException.class);
+
+        verify(orderRepository, never()).save(any());
+        verify(historyRecorder, never()).record(any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("이미 CANCELLATION_COMPLETED 인 주문은 재호출 시 InvalidStatusTransitionException")
+    void alreadyCancelled_invalidTransition() {
+        UUID buyerId = UUID.randomUUID();
+        Order order = OrderTestFixtures.paidOrder(buyerId, UUID.randomUUID());
+        order.cancel(Reason.of("buyer 변심"));
+        order.markCancelled();   // CANCELLATION_PROCESSING → CANCELLATION_COMPLETED
+        when(orderRepository.findByIdOrThrow(order.getId())).thenReturn(order);
+
+        assertThatThrownBy(() -> service.markCancelled(order.getId().value()))
+                .isInstanceOf(InvalidStatusTransitionException.class);
+
+        verify(orderRepository, never()).save(any());
+        verify(historyRecorder, never()).record(any(), any(), any(), any());
     }
 }

--- a/src/test/java/com/trustamarket/orderservice/order/application/service/command/MarkOrderCancelledServiceTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/application/service/command/MarkOrderCancelledServiceTest.java
@@ -40,7 +40,7 @@ class MarkOrderCancelledServiceTest {
         order.cancel(Reason.of("buyer 변심"));   // PAID → CANCELLATION_PROCESSING
         when(orderRepository.findByIdOrThrow(order.getId())).thenReturn(order);
 
-        service.markCancelled(order.getId().value());
+        service.markCancelled(order.getId());
 
         assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLATION_COMPLETED);
         verify(historyRecorder).record(order.getId(),
@@ -55,7 +55,7 @@ class MarkOrderCancelledServiceTest {
         when(orderRepository.findByIdOrThrow(OrderId.of(orderId)))
                 .thenThrow(new OrderNotFoundException(orderId));
 
-        assertThatThrownBy(() -> service.markCancelled(orderId))
+        assertThatThrownBy(() -> service.markCancelled(OrderId.of(orderId)))
                 .isInstanceOf(OrderNotFoundException.class);
 
         verify(orderRepository, never()).save(any());
@@ -71,7 +71,7 @@ class MarkOrderCancelledServiceTest {
         order.markCancelled();   // CANCELLATION_PROCESSING → CANCELLATION_COMPLETED
         when(orderRepository.findByIdOrThrow(order.getId())).thenReturn(order);
 
-        assertThatThrownBy(() -> service.markCancelled(order.getId().value()))
+        assertThatThrownBy(() -> service.markCancelled(order.getId()))
                 .isInstanceOf(InvalidStatusTransitionException.class);
 
         verify(orderRepository, never()).save(any());

--- a/src/test/java/com/trustamarket/orderservice/order/application/service/command/MarkOrderCancelledServiceTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/application/service/command/MarkOrderCancelledServiceTest.java
@@ -1,0 +1,44 @@
+package com.trustamarket.orderservice.order.application.service.command;
+
+import com.trustamarket.orderservice.order.application.port.out.OrderRepository;
+import com.trustamarket.orderservice.order.application.service.OrderTestFixtures;
+import com.trustamarket.orderservice.order.application.service.support.OrderHistoryRecorder;
+import com.trustamarket.orderservice.order.domain.model.Order;
+import com.trustamarket.orderservice.order.domain.model.OrderStatus;
+import com.trustamarket.orderservice.order.domain.model.Reason;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MarkOrderCancelledServiceTest {
+
+    @Mock OrderRepository orderRepository;
+    @Mock OrderHistoryRecorder historyRecorder;
+    @InjectMocks MarkOrderCancelledService service;
+
+    @Test
+    @DisplayName("CANCELLATION_PROCESSING → CANCELLATION_COMPLETED + history 기록")
+    void markCancelled() {
+        UUID buyerId = UUID.randomUUID();
+        Order order = OrderTestFixtures.paidOrder(buyerId, UUID.randomUUID());
+        order.cancel(Reason.of("buyer 변심"));   // PAID → CANCELLATION_PROCESSING
+        when(orderRepository.findByIdOrThrow(order.getId())).thenReturn(order);
+
+        service.markCancelled(order.getId().value());
+
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLATION_COMPLETED);
+        verify(historyRecorder).record(order.getId(),
+                OrderStatus.CANCELLATION_PROCESSING, OrderStatus.CANCELLATION_COMPLETED, null);
+        verify(orderRepository).save(order);
+    }
+}

--- a/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderStatusTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderStatusTest.java
@@ -14,7 +14,7 @@ class OrderStatusTest {
     private static final Set<OrderStatus> TERMINAL = Set.of(
             OrderStatus.CONFIRMED,
             OrderStatus.CANCELLED,
-            OrderStatus.REFUND_COMPLETED,
+            OrderStatus.CANCELLATION_COMPLETED,
             OrderStatus.RETURN_REJECTED,
             OrderStatus.RETURN_APPROVED
     );

--- a/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderTest.java
@@ -128,7 +128,7 @@ class OrderTest {
         }
 
         @Test
-        @DisplayName("PAID에서 cancel은 REFUND_PROCESSING")
+        @DisplayName("PAID에서 cancel은 CANCELLATION_PROCESSING")
         void cancelAfterPayment() {
             Order order = newOrder();
             order.requestPayment();
@@ -136,20 +136,20 @@ class OrderTest {
 
             order.cancel(Reason.of("환불"));
 
-            assertThat(order.getStatus()).isEqualTo(OrderStatus.REFUND_PROCESSING);
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLATION_PROCESSING);
         }
 
         @Test
-        @DisplayName("REFUND_PROCESSING에서 markRefunded는 REFUND_COMPLETED")
-        void markRefunded() {
+        @DisplayName("CANCELLATION_PROCESSING에서 markCancelled는 CANCELLATION_COMPLETED")
+        void markCancelled() {
             Order order = newOrder();
             order.requestPayment();
             order.markPaid();
             order.cancel(Reason.of("환불"));
 
-            order.markRefunded();
+            order.markCancelled();
 
-            assertThat(order.getStatus()).isEqualTo(OrderStatus.REFUND_COMPLETED);
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLATION_COMPLETED);
         }
 
         @Test
@@ -413,13 +413,13 @@ class OrderTest {
         }
 
         @Test
-        @DisplayName("CANCELLED/REFUND_PROCESSING/REFUND_COMPLETED는 cancelReason 필수")
+        @DisplayName("CANCELLED/CANCELLATION_PROCESSING/CANCELLATION_COMPLETED는 cancelReason 필수")
         void cancelledWithoutCancelReason() {
             assertThatThrownBy(() -> baseBuilder(OrderStatus.CANCELLED).build())
                     .isInstanceOf(RestoreStateMismatchException.class);
-            assertThatThrownBy(() -> baseBuilder(OrderStatus.REFUND_PROCESSING).build())
+            assertThatThrownBy(() -> baseBuilder(OrderStatus.CANCELLATION_PROCESSING).build())
                     .isInstanceOf(RestoreStateMismatchException.class);
-            assertThatThrownBy(() -> baseBuilder(OrderStatus.REFUND_COMPLETED).build())
+            assertThatThrownBy(() -> baseBuilder(OrderStatus.CANCELLATION_COMPLETED).build())
                     .isInstanceOf(RestoreStateMismatchException.class);
         }
 

--- a/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderTransitionTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderTransitionTest.java
@@ -32,9 +32,9 @@ class OrderTransitionTest {
                 // cancel
                 Arguments.of(OrderStatus.REQUESTED, OrderAction.CANCEL, OrderStatus.CANCELLED),
                 Arguments.of(OrderStatus.PAYMENT_PENDING, OrderAction.CANCEL, OrderStatus.CANCELLED),
-                Arguments.of(OrderStatus.PAID, OrderAction.CANCEL, OrderStatus.REFUND_PROCESSING),
+                Arguments.of(OrderStatus.PAID, OrderAction.CANCEL, OrderStatus.CANCELLATION_PROCESSING),
                 // refund
-                Arguments.of(OrderStatus.REFUND_PROCESSING, OrderAction.MARK_REFUNDED, OrderStatus.REFUND_COMPLETED),
+                Arguments.of(OrderStatus.CANCELLATION_PROCESSING, OrderAction.MARK_CANCELLED, OrderStatus.CANCELLATION_COMPLETED),
                 // return
                 Arguments.of(OrderStatus.SHIPPING, OrderAction.REQUEST_RETURN, OrderStatus.RETURN_REQUESTED),
                 Arguments.of(OrderStatus.DELIVERED, OrderAction.REQUEST_RETURN, OrderStatus.RETURN_REQUESTED),
@@ -56,7 +56,7 @@ class OrderTransitionTest {
                 // 종결 상태에서의 모든 액션
                 Arguments.of(OrderStatus.CONFIRMED, OrderAction.CANCEL),
                 Arguments.of(OrderStatus.CANCELLED, OrderAction.REQUEST_PAYMENT),
-                Arguments.of(OrderStatus.REFUND_COMPLETED, OrderAction.CANCEL),
+                Arguments.of(OrderStatus.CANCELLATION_COMPLETED, OrderAction.CANCEL),
                 Arguments.of(OrderStatus.RETURN_REJECTED, OrderAction.APPROVE_RETURN),
                 // 배송 시작 후 취소 차단
                 Arguments.of(OrderStatus.SHIPPING, OrderAction.CANCEL),

--- a/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderTransitionTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/domain/model/OrderTransitionTest.java
@@ -33,7 +33,7 @@ class OrderTransitionTest {
                 Arguments.of(OrderStatus.REQUESTED, OrderAction.CANCEL, OrderStatus.CANCELLED),
                 Arguments.of(OrderStatus.PAYMENT_PENDING, OrderAction.CANCEL, OrderStatus.CANCELLED),
                 Arguments.of(OrderStatus.PAID, OrderAction.CANCEL, OrderStatus.CANCELLATION_PROCESSING),
-                // refund
+                // cancellation
                 Arguments.of(OrderStatus.CANCELLATION_PROCESSING, OrderAction.MARK_CANCELLED, OrderStatus.CANCELLATION_COMPLETED),
                 // return
                 Arguments.of(OrderStatus.SHIPPING, OrderAction.REQUEST_RETURN, OrderStatus.RETURN_REQUESTED),


### PR DESCRIPTION
## 🌱 설명

PAID 후 cancel 흐름 완성 + 도메인 명명 정리.

(1) `REFUND_*` → `CANCELLATION_*` rename — 팀 컨벤션상 환불이 아니라 취소.  
(2) PAID cancel 시 Outbox publish → wallet escrow 복구 → 응답 consume → CANCELLATION_COMPLETED. wallet 팀과 토픽 / 페이로드 합의 중.

## 📌 관련 이슈

close #25

## ✅ 주요 변경 사항

### rename
- `OrderStatus.REFUND_PROCESSING / REFUND_COMPLETED` → `CANCELLATION_PROCESSING / CANCELLATION_COMPLETED`
- `OrderAction.MARK_REFUNDED` → `MARK_CANCELLED`
- `Order.markRefunded()` → `markCancelled()`
- `OrderTransition` 키 rename
- 8 파일 / 42 치환

### 이벤트 흐름
- `CancelOrderService` 의 PAID 분기에 `Events.trigger(OutboxEvent.of(..., ORDER.CANCELLATION_REQUESTED, payload))` 추가 — 결제 전 취소 (REQUESTED / PAYMENT_PENDING) 분기는 publish X
- 신규 `OrderCancellationRequestedMessage` (publish payload) — `application/event/messaging/`
- 신규 `WalletCancellationCompletedMessage` (consume payload) — `adapter/in/messaging/dto/`
- 신규 `MarkOrderCancelledUseCase` / `MarkOrderCancelledService`
- 신규 `WalletCancellationCompletedListener` — `wallet.cancellation.completed` consume + inbox 멱등성 + afterCommit ack

### inbox / outbox
- `InboxPurpose` / `InboxPurposeKey` 에 `WALLET_CANCELLATION_COMPLETED` 추가
- `OutboxEventListener` 의 토픽 매핑에 `EVENT_ORDER_CANCELLATION_REQUESTED` 추가
- `application.yaml` — 토픽 키 2개 추가

### Liquibase
- `006-rename-order-status-refund-to-cancellation.yaml` — 기존 row + status_history `prev_status` / `next_status` 일괄 UPDATE + rollback 명시

### 테스트
- 신규 `MarkOrderCancelledServiceTest`
- 기존 `CancelOrderServiceTest`, `OrderTest`, `OrderTransitionTest`, `OrderStatusTest` rename 반영

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

### 토픽 / 페이로드 (wallet 합의)

```

order.cancellation.requested  (order publish)
  UUID    eventId
  UUID    orderId
  UUID    buyerId
  long    cancelledAmount
  Instant cancelledAt

wallet.cancellation.completed (wallet publish)
  UUID    eventId
  UUID    orderId
  long    cancelledAmount
  Instant completedAt
```

### 시연 영향

- 정상 흐름 (결제 → 확정) 영향 X
- cancel 시연만 새로 가능 (단 wallet 측 listener / publisher 들어와야 e2e 동작)
- wallet 미진입 상태에서는 PAID cancel 시 outbox publish 까지만 진행, 이후 CANCELLATION_PROCESSING 에서 멈춤

### 후속 (이번 PR 외)

- `wallet.cancellation.failed` 처리 (escrow 부족 등) — happy path 우선
- 반송 (RETURN_*) 의 wallet 복구 — 동일 패턴, 별도 PR
- 외부 PG 환불 (Toss 등) — payment-service scope, 정책 미정
- 쿠폰 복구 이벤트 — 쿠폰 PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 지갑 취소 완료 메시지 자동 수신 처리 및 멱등성 기반 중복 방지
  * 결제 후 취소 시 지갑 회복을 위한 취소 요청 이벤트 자동 발행

* **개선사항**
  * 시스템 전반의 “환불” 흐름을 “취소” 흐름으로 전환하고 상태 전이 재정비
  * Kafka 토픽 매핑 및 관련 메시지 계약 정비

* **데이터베이스**
  * 취소 상태명 반영을 위한 마이그레이션 추가

* **테스트**
  * 취소 흐름 관련 단위/통합 테스트 추가·갱신

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/order-service/pull/26)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->