### PR TITLE
chore: GKE 배포 설정 추가 (order-service)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,55 @@
+name: Build & Deploy order-service
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      IMAGE: asia-northeast3-docker.pkg.dev/trusta-market-id/trusta-registry-services/order-service
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GCP (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/37902116541/locations/global/workloadIdentityPools/trusta-pool-github/providers/trusta-provider-github
+          service_account: trusta-sa-github-deployer@trusta-market-id.iam.gserviceaccount.com
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker auth
+        run: gcloud auth configure-docker asia-northeast3-docker.pkg.dev --quiet
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            --build-arg GPR_USER=${{ secrets.GPR_USER }} \
+            --build-arg GPR_TOKEN=${{ secrets.GPR_TOKEN }} \
+            -t $IMAGE:${{ github.sha }} -t $IMAGE:latest .
+
+      - name: Push image
+        run: docker push --all-tags $IMAGE
+
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: trusta-cluster
+          location: asia-northeast3-a
+
+      - name: Apply Deployment (with image tag substitution)
+        run: sed "s|PLACEHOLDER|${{ github.sha }}|g" k8s/deployment.yaml | kubectl apply -f -
+
+      - name: Apply Service
+        run: kubectl apply -f k8s/service.yaml
+
+      - name: Wait for rollout
+        run: kubectl rollout status deployment/order-service --timeout=5m

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1.7
+
+FROM gradle:8.10-jdk21-alpine AS builder
+WORKDIR /workspace
+
+ARG GPR_USER
+ARG GPR_TOKEN
+
+COPY settings.gradle build.gradle ./
+COPY gradle ./gradle
+RUN GPR_USER="$GPR_USER" GPR_TOKEN="$GPR_TOKEN" gradle dependencies --no-daemon
+
+COPY src ./src
+
+RUN GPR_USER="$GPR_USER" GPR_TOKEN="$GPR_TOKEN" gradle bootJar --no-daemon \
+ && cp build/libs/*.jar /workspace/app.jar
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+
+RUN addgroup -g 1000 -S spring && adduser -u 1000 -S spring -G spring
+
+COPY --from=builder --chown=spring:spring /workspace/app.jar /app/app.jar
+
+USER spring:spring
+
+EXPOSE 8103
+
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-jar", "/app/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -37,9 +37,10 @@ ext {
 }
 
 dependencies {
-	implementation 'com.trustamarket:common:0.0.1-SNAPSHOT'
+	implementation 'com.trustamarket:common:0.1.0-SNAPSHOT'
 	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: order-service
+  labels:
+    app: order-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: order-service
+  template:
+    metadata:
+      labels:
+        app: order-service
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: order-service
+          image: asia-northeast3-docker.pkg.dev/trusta-market-id/trusta-registry-services/order-service:PLACEHOLDER
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - containerPort: 8103
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "k8s"
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: domain-postgres-secrets
+                  key: DB_USERNAME
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: domain-postgres-secrets
+                  key: DB_PASSWORD
+            # Kafka 미연결 상태에서도 startup OK (spring-kafka 는 lazy connect).
+            # Kafka VM 셋업 후 ConfigMap 또는 env override.
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 1000m
+              memory: 2Gi
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8103
+            failureThreshold: 30
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8103
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8103
+            periodSeconds: 5

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: order-service
+  labels:
+    app: order-service
+spec:
+  type: ClusterIP
+  selector:
+    app: order-service
+  ports:
+    - port: 80
+      targetPort: 8103
+      protocol: TCP

--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -1,0 +1,29 @@
+# K8s 환경 전용 override (SPRING_PROFILES_ACTIVE=k8s 일 때만 로드).
+# config-server (Pod) 가 config-repo 의 order-service.yml 도 가져옴 — 둘이 같이 적용.
+
+server:
+  # config-server 못 닿을 때를 대비한 default. config-server 에서 가져오면 그 값 우선.
+  port: 8103
+
+spring:
+  config:
+    # K8s 안에선 config-server Service 로 직접 호출.
+    import: "optional:configserver:http://config-server"
+  cloud:
+    config:
+      uri: http://config-server
+      label: develop
+      fail-fast: false
+  datasource:
+    # 도메인 공유 PG (Cloud SQL 마이그레이션은 PRD §9-#10 후속).
+    # username / password 는 Deployment env 의 secretKeyRef 로 주입.
+    url: jdbc:postgresql://postgres:5432/trusta_market
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://eureka-server/eureka/
+    register-with-eureka: true
+    fetch-registry: true
+  instance:
+    prefer-ip-address: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -40,3 +40,13 @@ trusta:
       delivery-completed:             delivery.completed
       order-cancellation-requested:   order.cancellation.requested
       wallet-cancellation-completed:  wallet.cancellation.completed
+
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus


### PR DESCRIPTION
## 🌱 설명

order-service GKE 배포 셋업. 도메인 공유 PG + config-server + Eureka 와 연동.

## 📌 관련 이슈

해당 없음 (인프라 셋업)

## ✅ 주요 변경 사항

- `application.yaml` — management 블록 추가 (health probes + prometheus)
- `application-k8s.yml` (신규) — Spring Profile k8s: config-server URI, datasource URL, Eureka URL 등 K8s service DNS 로 override
- `build.gradle` — `micrometer-registry-prometheus` 추가
- `Dockerfile` — multi-stage + non-root spring user (UID 1000), `ARG GPR_USER/GPR_TOKEN` 으로 common 의존성 fetch
- `k8s/deployment.yaml` — replicas 1, env SPRING_PROFILES_ACTIVE=k8s + DB Secret (domain-postgres-secrets), securityContext, probes
- `k8s/service.yaml` — ClusterIP `port 80 → targetPort 8103`
- `.github/workflows/deploy.yml` — WIF + AR + GKE 배포

## 🔧 머지 전 필수

- Secret `domain-postgres-secrets` 이미 존재 (이전 작업)
- repo secret `GPR_USER`, `GPR_TOKEN` 이미 등록

## 🧪 검증

```bash
kubectl get pods -l app=order-service
kubectl logs deployment/order-service --tail=80
```

## 📚 후속

- Kafka 별도 GCE VM 셋업 완료 후 KAFKA_BOOTSTRAP env 또는 ConfigMap 으로 연결 (현재 미연결 — startup 자체엔 영향 X, listener 만 동작 X)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 헬스 체크 및 모니터링 엔드포인트가 노출되어 서비스 상태를 확인할 수 있습니다.
  * Prometheus 메트릭 수집이 활성화되었습니다.

* **Chores**
  * 서비스가 컨테이너화되고 Kubernetes 환경에 배포될 준비가 완료되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/order-service/pull/28)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->