### PR TITLE
chore: common 0.2.0-SNAPSHOT bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ ext {
 }
 
 dependencies {
-	implementation 'com.trustamarket:common:0.1.0-SNAPSHOT'
+	implementation 'com.trustamarket:common:0.2.0-SNAPSHOT'
 	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'


### PR DESCRIPTION
trusta-market/common#5 fix 적용. async thread 에서 X-User-* 헤더 snapshot + SecurityContext 복사 전파. payment/wallet 의 internal Feign 401 해결.