### PR TITLE
fix: trust-gateway-headers 활성 (인증 path 401 해결)

### DIFF
--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -36,3 +36,9 @@ eureka:
     fetch-registry: true
   instance:
     prefer-ip-address: true
+
+# common 의 LoginFilter 가 gateway 의 X-User-* 헤더 → SecurityContext 로 주입.
+# false (default) 면 LoginFilter skip → 인증 path 401.
+trusta:
+  security:
+    trust-gateway-headers: true


### PR DESCRIPTION
## 🌱 설명

common 의 LoginFilter 는 `trusta.security.trust-gateway-headers=true` 일 때만 X-User-* 헤더 읽어 SecurityContext 세팅. 설정 없으면 LoginFilter 통째로 skip → 인증 path 401.

## 📌 관련 이슈

-

## ✅ 주요 변경 사항

- `application-k8s.yml` 에 `trusta.security.trust-gateway-headers: true` 추가

## 📚 추가 설명

- payment 의 PR #33, inspection 의 PR #47 과 동일 fix
- order/delivery/notification/user 의 K8s 프로필이 공통 누락 → 일괄 적용