### PR TITLE
fix: ProductFeignClient / WalletFeignClient 의 url= 옵션 제거

### DIFF
--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/product/ProductFeignClient.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/product/ProductFeignClient.java
@@ -9,10 +9,7 @@ import java.util.UUID;
 
 // product-service 의 internal API (`GET /internal/v1/products/{id}`) 호출.
 // X-User-* 헤더는 common FeignConfig 의 RequestInterceptor 가 자동 전파.
-@FeignClient(
-        name = "product-service",
-        url = "${trusta.product-service.url:http://localhost:8102}"
-)
+@FeignClient(name = "product-service")
 public interface ProductFeignClient {
 
     @GetMapping("/internal/v1/products/{productId}")

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletFeignClient.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletFeignClient.java
@@ -9,11 +9,7 @@ import java.util.UUID;
 
 // wallet-service `/internal/v1/wallets/usages` 호출용 Feign client.
 // X-User-* / Authorization 등 인증 헤더는 common FeignConfig 의 RequestInterceptor 가 자동 전파.
-// url 은 우선 명시 (Eureka 디스커버리 + LoadBalancer 정상화 전 안전망). prod 에선 lb://wallet-service 로 교체 가능.
-@FeignClient(
-        name = "wallet-service",
-        url = "${trusta.wallet-service.url:http://localhost:8302}"
-)
+@FeignClient(name = "wallet-service")
 public interface WalletFeignClient {
 
     @PatchMapping("/internal/v1/wallets/usages")


### PR DESCRIPTION
## 🌱 설명

POST /api/v1/orders 호출 시 502 Bad Gateway — order 가 product 호출 실패.

원인: order 의 두 Feign client 가 url= localhost:XXXX default. url 명시되면 Eureka service discovery 무시하고 직접 URL 호출 → K8s 에선 localhost = 자기 자신 = connection refused = 502.

```java
@FeignClient(name = "product-service", url = "${trusta.product-service.url:http://localhost:8102}")
@FeignClient(name = "wallet-service",  url = "${trusta.wallet-service.url:http://localhost:8302}")
```

## ✅ 주요 변경 사항

- ProductFeignClient / WalletFeignClient 의 `url=` 옵션 제거 → `@FeignClient(name = ...)` 만
- application-k8s.yml 의 trusta.product-service.url / wallet-service.url 도 제거 (필요 없어짐)

## 📚 추가 설명

- 다른 서비스 (user/wallet/payment/delivery) 의 Feign client 들은 이미 url= 없이 service discovery 만 사용 — order 만 outlier 였음. 일관 패턴으로 통일.
- 로컬 dev 영향: order 단독 띄울 때 Eureka + 의존 서비스 (product, wallet) 도 같이 띄워야 함. 다른 서비스들도 이미 그렇게 운영 중이라 동일 패턴.
- 확장성: 새 Feign client 추가 시 url= / config 박을 필요 X. name 만으로 자동.