### PR TITLE
chore(db): p_order schema 분리 (Liquibase + JPA default-schema)

### DIFF
--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -27,6 +27,15 @@ spring:
   # Kafka — GKE namespace 'kafka' 의 StatefulSet 3 broker. 새 cluster (별도 CLUSTER_ID), 토픽 초기화됨.
   kafka:
     bootstrap-servers: kafka.kafka:9092
+  # 도메인별 schema 분리 — service 간 databasechangelog 충돌 + 데이터 격리.
+  liquibase:
+    default-schema: p_order
+    liquibase-schema: p_order
+  jpa:
+    properties:
+      hibernate:
+        # JPA entity 의 @Table 에 schema 명시 없을 때 사용할 default schema.
+        default_schema: p_order
 
 eureka:
   client:


### PR DESCRIPTION
## 🌱 설명

order-service 의 DB 테이블 + Liquibase 메타 테이블 (`databasechangelog`, `databasechangeloglock`) 을 `p_order` schema 로 분리. service 간 `databasechangelog` 공유로 인한 id/author 충돌 + lock 경합 + 데이터 격리 X 문제 해결.

DB 작업 (이미 수행됨, transaction 으로):
- `CREATE SCHEMA p_order`
- `ALTER TABLE` 로 `public.p_order` / `p_order_inbox` / `p_order_outbox` / `p_order_status_history` → `p_order` schema 로 이동
- `p_order.databasechangelog` / `databasechangeloglock` 새로 생성 + `author='lhk'` row 복사
- `public.databasechangelog` 에서 lhk row DELETE

## 📌 관련 이슈

close #

## ✅ 주요 변경 사항

- `application-k8s.yml` 의 `spring.liquibase.default-schema` + `liquibase-schema` 를 `p_order` 로
- `spring.jpa.properties.hibernate.default_schema=p_order` — entity @Table 에 schema 명시 없을 때 적용

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

머지 + 재배포 시점에 service 가 `p_order.databasechangelog` 의 6 row 가 다 실행됨으로 인식 → DDL 재실행 X → 정상 부팅. JPA query 도 `p_order.*` 로 schema prefix 가 붙음.

다른 service (user/product/wallet/payment/delivery/inspection/notification) 도 같은 패턴 (`p_<svc>` schema 분리) 으로 진행 예정.
