### PR TITLE
ci(deploy): fail 시 notify-deploy-failure 호출 (Discord 알람 + log preview)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,3 +53,15 @@ jobs:
 
       - name: Wait for rollout
         run: kubectl rollout status deployment/order-service --timeout=5m
+
+  # deploy job 의 어느 step 이라도 실패 시 — trusta-monitoring 의 reusable workflow 호출.
+  # kubectl logs --previous --tail=50 으로 pod log 추출 + notification-service webhook POST → Discord.
+  notify-failure:
+    needs: deploy
+    if: failure()
+    uses: trusta-market/trusta-monitoring/.github/workflows/notify-deploy-failure.yml@main
+    with:
+      service: order-service
+    permissions:
+      contents: read
+      id-token: write


### PR DESCRIPTION
## 🌱 설명

deploy workflow 가 fail 시 `trusta-monitoring` 의 reusable workflow 호출 → notification-service webhook → Discord 🚧 알람 + log preview + run URL.

검증 후 다른 service 도 같은 패턴 적용 예정.

## ✅ 주요 변경 사항

- `.github/workflows/deploy.yml` 끝에 `notify-failure` job 추가 (`needs: deploy` + `if: failure()`)
- `uses: trusta-market/trusta-monitoring/.github/workflows/notify-deploy-failure.yml@main`

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

trusta-market org settings 의 Actions → Workflow permissions → "Allow accessing workflows from other repositories within the organization" 가 enable 되어 있어야 cross-repo reusable workflow 호출 가능. 안 되어 있으면 setting 변경 + retry.

호출 측 (notification-service) endpoint: PR #11 머지 후 동작.

다른 9 service 도 같은 한 줄 패치 — 검증 후 일괄 또는 별도 PR.