### PR TITLE
revert(ci): notify-failure 호출 제거 — order-service 배포 unblock

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,15 +53,3 @@ jobs:
 
       - name: Wait for rollout
         run: kubectl rollout status deployment/order-service --timeout=5m
-
-  # deploy job 의 어느 step 이라도 실패 시 — trusta-monitoring 의 reusable workflow 호출.
-  # kubectl logs --previous --tail=50 으로 pod log 추출 + notification-service webhook POST → Discord.
-  notify-failure:
-    needs: deploy
-    if: failure()
-    uses: trusta-market/trusta-monitoring/.github/workflows/notify-deploy-failure.yml@main
-    with:
-      service: order-service
-    permissions:
-      contents: read
-      id-token: write


### PR DESCRIPTION
## 🌱 설명

PR #39 머지 후 `error parsing called workflow ... workflow was not found` 로 deploy workflow 가 매번 fail. order-service 의 모든 배포가 막힘 → 즉시 unblock.

trusta-monitoring 의 access level (`organization`), file 존재, ref `@main` 다 OK 확인했지만 caller 가 못 찾음. 원인 미상.

reusable workflow 디버그는 별도 진행 후 다시 enable.

## ✅ 주요 변경 사항

- `.github/workflows/deploy.yml` 의 `notify-failure` job 제거

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

머지 후 deploy workflow 정상 동작 확인 → reusable workflow 측 디버그 → 다시 enable PR.