### PR TITLE
[fix] order/payment 의 feign call 트랜잭션 밖으로 분리 (saga)

### DIFF
--- a/src/main/java/com/trustamarket/orderservice/config/TransactionConfig.java
+++ b/src/main/java/com/trustamarket/orderservice/config/TransactionConfig.java
@@ -1,0 +1,18 @@
+package com.trustamarket.orderservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+// TransactionTemplate 빈 등록.
+// Saga 패턴 (CreateOrderService / RequestPaymentService) 에서 Feign call 을 tx 밖으로 빼기 위해
+// 짧은 DB 작업만 tx 안에 명시적으로 묶을 때 사용.
+@Configuration
+public class TransactionConfig {
+
+    @Bean
+    public TransactionTemplate transactionTemplate(PlatformTransactionManager txManager) {
+        return new TransactionTemplate(txManager);
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/command/CreateOrderService.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/command/CreateOrderService.java
@@ -13,28 +13,18 @@ import com.trustamarket.orderservice.order.domain.model.Order;
 import com.trustamarket.orderservice.order.domain.model.OrderStatus;
 import com.trustamarket.orderservice.order.domain.model.Product;
 import com.trustamarket.orderservice.order.domain.model.Seller;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
+@RequiredArgsConstructor
 public class CreateOrderService implements CreateOrderUseCase {
 
     private final OrderRepository orderRepository;
     private final OrderHistoryRecorder historyRecorder;
     private final ProductInfoPort productInfoPort;
     private final TransactionTemplate txTemplate;
-
-    public CreateOrderService(
-            OrderRepository orderRepository,
-            OrderHistoryRecorder historyRecorder,
-            ProductInfoPort productInfoPort,
-            PlatformTransactionManager txManager) {
-        this.orderRepository = orderRepository;
-        this.historyRecorder = historyRecorder;
-        this.productInfoPort = productInfoPort;
-        this.txTemplate = new TransactionTemplate(txManager);
-    }
 
     @Override
     public CreateOrderResult createOrder(CreateOrderCommand cmd) {

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentService.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentService.java
@@ -20,13 +20,19 @@ import com.trustamarket.orderservice.order.domain.model.OrderId;
 import com.trustamarket.orderservice.order.domain.model.OrderStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 // REQUESTED → PAYMENT_PENDING → (Wallet sync) → PAID
-// 잔액 부족 시: throw → @Transactional 자동 롤백 → REQUESTED 복귀 → 클라가 충전 후 재시도
+// Saga 분리: wallet feign call 이 tx 밖이라 connection hold X.
+//   [tx1] order load + requestPayment() — PAYMENT_PENDING commit (짧음, ~50ms)
+//   [no tx] walletPaymentPort.deduct() — Feign 호출 (응답 timeout 5초까지 wait, connection 없음)
+//   [tx2] 성공: markPaid() + outbox publish (commit)
+//          실패: rollbackPaymentRequest() — PAYMENT_PENDING → REQUESTED (보상)
+//
+// 보상 실패 시 (tx2 의 rollback 자체가 fail) order 가 PAYMENT_PENDING 으로 stuck.
+// → 별도 reconciliation job 필요 (현재 미구현, follow-up).
 //
 // Idempotency-Key 검증: RequestPaymentCommand compact constructor 가 NotBlank 보장.
-// 따라서 본 메서드는 cmd.idempotencyKey() 가 항상 non-blank 라고 가정.
 @Service
 @RequiredArgsConstructor
 public class RequestPaymentService implements RequestPaymentUseCase {
@@ -37,9 +43,9 @@ public class RequestPaymentService implements RequestPaymentUseCase {
     private final OrderHistoryRecorder historyRecorder;
     private final WalletPaymentPort walletPaymentPort;
     private final InboxRepository inboxRepository;
+    private final TransactionTemplate txTemplate;
 
     @Override
-    @Transactional
     public void requestPayment(RequestPaymentCommand cmd) {
         // 멱등성 — atomic INSERT 시도. 이미 처리된 키면 false 반환 → no-op.
         // (REQUIRES_NEW 트랜잭션이라 충돌 시 부모 트랜잭션 영향 없음.)
@@ -47,62 +53,78 @@ public class RequestPaymentService implements RequestPaymentUseCase {
             return;
         }
 
-        Order order = orderRepository.findByIdOrThrow(OrderId.of(cmd.orderId()));
-        OrderAccessGuard.verifyBuyer(order, cmd.buyerId());
+        OrderId orderId = OrderId.of(cmd.orderId());
 
-        OrderStatus pre = order.getStatus();
-        order.requestPayment();   // REQUESTED → PAYMENT_PENDING
-        historyRecorder.record(order.getId(), pre, order.getStatus(), null);
+        // ── [tx1] 짧은 DB UPDATE: REQUESTED → PAYMENT_PENDING ──
+        Long totalAmount = txTemplate.execute(status -> {
+            Order order = orderRepository.findByIdOrThrow(orderId);
+            OrderAccessGuard.verifyBuyer(order, cmd.buyerId());
 
-        DeductPointResponse res = callWallet(cmd, order);
+            OrderStatus pre = order.getStatus();
+            order.requestPayment();
+            historyRecorder.record(order.getId(), pre, order.getStatus(), null);
+            orderRepository.save(order);
+            return order.getTotalAmount().value();
+        });
+
+        // ── [no tx] Wallet Feign 호출 (DB connection 없음) ──
+        DeductPointResponse res;
+        try {
+            res = walletPaymentPort.deduct(
+                    new DeductPointRequest(cmd.orderId(), cmd.buyerId(), totalAmount)
+            );
+            if (res == null) {
+                compensateToRequested(orderId);
+                throw new WalletCommunicationException();
+            }
+        } catch (com.trustamarket.orderservice.order.domain.exception.OrderException e) {
+            compensateToRequested(orderId);
+            throw e;
+        } catch (RuntimeException e) {
+            compensateToRequested(orderId);
+            throw new WalletCommunicationException(e);
+        }
+
         if (!res.isSuccess()) {
+            compensateToRequested(orderId);
             throw new InsufficientPointBalanceException(
-                    order.getTotalAmount().value(),
+                    totalAmount,
                     res.balance() == null ? 0 : res.balance(),
                     res.shortage()
             );
         }
 
-        // Wallet 성공 → 즉시 PAID 전이.
-        OrderStatus prePaid = order.getStatus();
-        order.markPaid();
-        historyRecorder.record(order.getId(), prePaid, order.getStatus(), null);
+        // ── [tx2] 짧은 DB UPDATE: PAYMENT_PENDING → PAID + outbox publish ──
+        txTemplate.execute(status -> {
+            Order order = orderRepository.findByIdOrThrow(orderId);
+            OrderStatus prePaid = order.getStatus();
+            order.markPaid();
+            historyRecorder.record(order.getId(), prePaid, order.getStatus(), null);
+            orderRepository.save(order);
 
-        orderRepository.save(order);
-
-        Events.trigger(OutboxEvent.of(
-                DOMAIN_TYPE, order.getId().value(),
-                OrderEventTypes.ORDER_PAID,
-                OrderPaidMessage.of(
-                        order.getId().value(),
-                        order.getProduct().id(),
-                        order.getSeller().id(),
-                        order.getBuyer().id(),
-                        order.getType().name())));
-
-        // 멱등성 키는 진입부 tryRecordIdempotencyKey 에서 이미 INSERT 됨.
-        // 본 트랜잭션이 rollback 되면 inbox 도 같이 rollback 되어야 하는데, REQUIRES_NEW 라 분리됨 →
-        // wallet 차감 실패 등으로 이 메서드가 throw 시 inbox 만 남는 케이스 발생 가능.
-        // 트레이드오프: TOCTOU race 차단을 우선. 잔여 inbox row 는 결과 없이 멱등성 키만 점유 → 동일 키 재시도 시 단순 no-op (의도된 동작).
-        // 정산 발행은 ConfirmOrderService 로 이동 (구매 확정 후 분배).
+            Events.trigger(OutboxEvent.of(
+                    DOMAIN_TYPE, order.getId().value(),
+                    OrderEventTypes.ORDER_PAID,
+                    OrderPaidMessage.of(
+                            order.getId().value(),
+                            order.getProduct().id(),
+                            order.getSeller().id(),
+                            order.getBuyer().id(),
+                            order.getType().name())));
+            return null;
+        });
     }
 
-    // Wallet 동기 호출 + null 응답/예외를 도메인 예외로 일관 변환.
-    // 도메인 예외 (OrderException 상속) 는 검증/비즈니스 오류라 그대로 전파.
-    // 그 외 RuntimeException (통신 장애, NPE 등) 만 WalletCommunicationException 으로 변환.
-    private DeductPointResponse callWallet(RequestPaymentCommand cmd, Order order) {
-        try {
-            DeductPointResponse res = walletPaymentPort.deduct(
-                    new DeductPointRequest(cmd.orderId(), cmd.buyerId(), order.getTotalAmount().value())
-            );
-            if (res == null) {
-                throw new WalletCommunicationException();
-            }
-            return res;
-        } catch (com.trustamarket.orderservice.order.domain.exception.OrderException e) {
-            throw e;
-        } catch (RuntimeException e) {
-            throw new WalletCommunicationException(e);
-        }
+    // Saga 보상 — PAYMENT_PENDING → REQUESTED 복귀.
+    // 본 트랜잭션은 항상 commit 시도. 실패 시 order 가 PAYMENT_PENDING 으로 stuck → reconciliation job 으로 복구 (follow-up).
+    private void compensateToRequested(OrderId orderId) {
+        txTemplate.execute(status -> {
+            Order order = orderRepository.findByIdOrThrow(orderId);
+            OrderStatus pre = order.getStatus();
+            order.rollbackPaymentRequest();
+            historyRecorder.record(order.getId(), pre, order.getStatus(), null);
+            orderRepository.save(order);
+            return null;
+        });
     }
 }

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/Order.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/Order.java
@@ -245,6 +245,13 @@ public class Order {
         this.status = OrderTransition.apply(this.status, OrderAction.REQUEST_PAYMENT);
     }
 
+    // PAYMENT_PENDING → REQUESTED (saga 보상)
+    // Wallet 호출 실패 / 잔액 부족 / null 응답 시 결제 시도 전 상태로 복귀.
+    // 클라가 다시 결제 시도 가능 (멱등성 키는 inbox 에 잔류 → 동일 키는 no-op).
+    public void rollbackPaymentRequest() {
+        this.status = OrderTransition.apply(this.status, OrderAction.ROLLBACK_PAYMENT);
+    }
+
     // PAYMENT_PENDING → PAID
     // Wallet의 PaymentCompleted 이벤트 수신 시
     public void markPaid() {

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderAction.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderAction.java
@@ -4,6 +4,7 @@ package com.trustamarket.orderservice.order.domain.model;
 public enum OrderAction {
 
     REQUEST_PAYMENT,      // REQUESTED → PAYMENT_PENDING
+    ROLLBACK_PAYMENT,     // PAYMENT_PENDING → REQUESTED (wallet 호출 실패 시 saga 보상)
     MARK_PAID,            // PAYMENT_PENDING → PAID
     START_SHIPPING,       // PAID → SHIPPING
     MARK_DELIVERED,       // SHIPPING → DELIVERED

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderTransition.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/OrderTransition.java
@@ -12,6 +12,7 @@ import static com.trustamarket.orderservice.order.domain.model.OrderAction.MARK_
 import static com.trustamarket.orderservice.order.domain.model.OrderAction.MARK_CANCELLED;
 import static com.trustamarket.orderservice.order.domain.model.OrderAction.REJECT_RETURN;
 import static com.trustamarket.orderservice.order.domain.model.OrderAction.REQUEST_PAYMENT;
+import static com.trustamarket.orderservice.order.domain.model.OrderAction.ROLLBACK_PAYMENT;
 import static com.trustamarket.orderservice.order.domain.model.OrderAction.REQUEST_RETURN;
 import static com.trustamarket.orderservice.order.domain.model.OrderAction.START_SHIPPING;
 import static com.trustamarket.orderservice.order.domain.model.OrderStatus.CANCELLED;
@@ -40,6 +41,7 @@ public final class OrderTransition {
             // Happy path — REQUESTED부터 CONFIRMED까지. CONFIRMED가 거래 종결
             // Map.entry((현재상태+액션) -> 다음 상태)
             Map.entry(new Key(REQUESTED,             REQUEST_PAYMENT),  PAYMENT_PENDING),
+            Map.entry(new Key(PAYMENT_PENDING,       ROLLBACK_PAYMENT), REQUESTED),
             Map.entry(new Key(PAYMENT_PENDING,       MARK_PAID),        PAID),
             Map.entry(new Key(PAID,                  START_SHIPPING),   SHIPPING),
             Map.entry(new Key(SHIPPING,              MARK_DELIVERED),   DELIVERED),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,6 +12,15 @@ spring:
     config:
       label: develop
       fail-fast: false
+    # Feign client timeout — 기본 무한 이라 wallet/product-service 응답 늦으면 호출 thread 가
+    # tx 안에서 connection 무한 hold → 1000 VU 부하 시 HikariCP pool 즉시 고갈 cascade.
+    # 5초 read timeout 으로 fail-fast → connection 빨리 반환.
+    openfeign:
+      client:
+        config:
+          default:
+            connect-timeout: 1000
+            read-timeout: 5000
 
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP:localhost:9092}

--- a/src/test/java/com/trustamarket/orderservice/order/application/service/command/CreateOrderServiceTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/application/service/command/CreateOrderServiceTest.java
@@ -11,12 +11,15 @@ import com.trustamarket.orderservice.order.domain.model.Order;
 import com.trustamarket.orderservice.order.domain.model.OrderId;
 import com.trustamarket.orderservice.order.domain.model.OrderStatus;
 import com.trustamarket.orderservice.order.domain.model.OrderType;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.UUID;
 
@@ -26,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -36,7 +40,16 @@ class CreateOrderServiceTest {
     @Mock OrderRepository orderRepository;
     @Mock OrderHistoryRecorder historyRecorder;
     @Mock ProductInfoPort productInfoPort;
+    @Mock TransactionTemplate txTemplate;
     @InjectMocks CreateOrderService service;
+
+    @BeforeEach
+    void setUpTxTemplate() {
+        lenient().when(txTemplate.execute(any())).thenAnswer(inv -> {
+            TransactionCallback<?> cb = inv.getArgument(0);
+            return cb.doInTransaction(null);
+        });
+    }
 
     @Test
     @DisplayName("주문 생성 — happy path (product ON_SALE)")

--- a/src/test/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentServiceTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentServiceTest.java
@@ -12,19 +12,24 @@ import com.trustamarket.orderservice.order.application.service.support.OrderHist
 import com.trustamarket.orderservice.order.domain.exception.InsufficientPointBalanceException;
 import com.trustamarket.orderservice.order.domain.model.Order;
 import com.trustamarket.orderservice.order.domain.model.OrderStatus;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -35,7 +40,18 @@ class RequestPaymentServiceTest {
     @Mock OrderHistoryRecorder historyRecorder;
     @Mock WalletPaymentPort walletPaymentPort;
     @Mock InboxRepository inboxRepository;
+    @Mock TransactionTemplate txTemplate;
     @InjectMocks RequestPaymentService service;
+
+    @BeforeEach
+    void setUpTxTemplate() {
+        // txTemplate.execute(callback) 가 callback 을 즉시 실행하도록 stub
+        // (실 트랜잭션 동작은 통합 테스트 에서 검증)
+        lenient().when(txTemplate.execute(any())).thenAnswer(inv -> {
+            TransactionCallback<?> cb = inv.getArgument(0);
+            return cb.doInTransaction(null);
+        });
+    }
 
     @Test
     @DisplayName("결제 시작 — Wallet 성공 → PAID 전이 + history 2건 + inbox 첫 INSERT")
@@ -52,7 +68,8 @@ class RequestPaymentServiceTest {
         assertThat(order.getStatus()).isEqualTo(OrderStatus.PAID);
         verify(historyRecorder).record(order.getId(), OrderStatus.REQUESTED, OrderStatus.PAYMENT_PENDING, null);
         verify(historyRecorder).record(order.getId(), OrderStatus.PAYMENT_PENDING, OrderStatus.PAID, null);
-        verify(orderRepository).save(order);
+        // saga 분리: segment 1 (PAYMENT_PENDING) + segment 2 (PAID) 두 번 save
+        verify(orderRepository, times(2)).save(order);
     }
 
     @Test
@@ -70,7 +87,7 @@ class RequestPaymentServiceTest {
     }
 
     @Test
-    @DisplayName("잔액 부족 → InsufficientPointBalanceException, save 호출 X")
+    @DisplayName("잔액 부족 → InsufficientPointBalanceException, REQUESTED 로 보상 (saga)")
     void insufficientBalance() {
         UUID buyerId = UUID.randomUUID();
         String idempotencyKey = UUID.randomUUID().toString();
@@ -83,7 +100,10 @@ class RequestPaymentServiceTest {
                 service.requestPayment(new RequestPaymentCommand(order.getId().value(), buyerId, idempotencyKey))
         ).isInstanceOf(InsufficientPointBalanceException.class);
 
-        verify(orderRepository, never()).save(any(Order.class));
+        // saga 분리: segment 1 (PAYMENT_PENDING save) + 보상 (rollbackPaymentRequest → REQUESTED save) = 2번
+        verify(orderRepository, times(2)).save(any(Order.class));
+        // 최종 상태는 REQUESTED 로 복귀 (재시도 가능)
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.REQUESTED);
     }
 
     @Test


### PR DESCRIPTION
## 🌱 설명

1000 VU 부하 테스트에서 order create / payment p95 30s+ 폭증 + 도메인 서비스 cascade restart 관찰.

원인: `CreateOrderService.createOrder()` 와 `RequestPaymentService.requestPayment()` 의 외부 서비스 (product-service / wallet-service) Feign 호출이 `@Transactional` 안에 있어, 응답 대기 동안 HikariCP connection 점유 → pool 10 즉시 고갈 → 후속 요청 acquire timeout cascade.

본 PR 은 두 service 에서 Feign call 을 트랜잭션 밖으로 분리. payment 는 saga 패턴 (3-segment + 보상) 적용.

## 📌 관련 이슈

close #47

## ✅ 주요 변경 사항

- `CreateOrderService`: `productInfoPort.fetch()` 를 트랜잭션 밖으로. DB INSERT 만 `TransactionTemplate` 안에서 처리
- `RequestPaymentService`: 3-segment saga 분리
  - `[tx1]` `order.requestPayment()` → PAYMENT_PENDING commit
  - `[no tx]` `walletPaymentPort.deduct()` Feign 호출
  - `[tx2]` 성공: `markPaid()` + outbox publish / 실패: `rollbackPaymentRequest()` 보상
- `Order` 도메인: `rollbackPaymentRequest()` 메소드 추가 (PAYMENT_PENDING → REQUESTED)
- `OrderAction` enum + `OrderTransition` 매핑: `ROLLBACK_PAYMENT` 추가
- `TransactionConfig`: `TransactionTemplate` @Bean 등록
- `application.yaml`: Feign client `connect-timeout: 1s` / `read-timeout: 5s` 명시 (이전 무한 → fail-fast)
- 테스트: 두 service test 에 `TransactionTemplate` mock + saga 분리 후 동작 검증

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치 생성
- [x] 기존 컨벤션 (헥사고날 / @Transactional 위치) 따름
- [x] 관련 이슈 (#47) 연결
- [x] 어려운 부분 (saga 보상 로직) 코드 주석 추가
- [x] 셀프 리뷰
- [x] 전체 184 tests 통과 (`./gradlew build` 통과)

## 📚 추가 설명

### Connection hold 시간 변화

| | Before | After |
|---|---|---|
| order create | Feign 응답까지 (~30s+) | DB INSERT만 (~50ms) |
| payment | Feign 응답까지 (~30s+) | DB INSERT만 × 2 (~100ms) |

= HikariCP pool 10 그대로도 throughput 크게 개선 예상.

### 정합성 보장

- 정상 흐름: 두 segment 모두 atomic commit
- wallet 잔액 부족 / null 응답: 보상 tx 자동 호출 → REQUESTED 복귀, 클라 재시도 가능
- wallet timeout 시 (실제 차감됐는데 응답 못 받음): order 만 복귀, wallet 차감 잔존 → 불일치 가능 → **follow-up issue #48**

### Follow-up (별도)

- #48 — wallet 측 reverse / 멱등성 / reconciliation job

### 부하 검증

배포 후 1000 VU burst 재측정 예정. 기대치:
- order create p95: 30s → < 1s
- payment 통과율: 8% → 큰 폭 개선

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 결제 요청 처리 중 오류 발생 시 자동으로 이전 상태로 복구하는 보상 메커니즘 추가
  * 외부 서비스 호출 시 타임아웃 설정 추가로 안정성 개선
  * 주문 결제 단계의 트랜잭션 처리 로직 최적화

* **테스트**
  * 결제 시나리오 테스트 케이스 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/order-service/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->