### PR TITLE
[fix] order create 의 product 조회 Caffeine cache 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,8 @@ dependencies {
 	implementation 'io.github.openfeign:feign-hc5'
 	implementation 'org.springframework.kafka:spring-kafka'
 	implementation 'org.liquibase:liquibase-core'
+	// caffeine — in-JVM cache (ProductInfoCachePort adapter 구현). 나중에 Redis adapter 추가 시 같은 port.
+	implementation 'com.github.ben-manes.caffeine:caffeine'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/product/CaffeineProductInfoCache.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/product/CaffeineProductInfoCache.java
@@ -1,0 +1,41 @@
+package com.trustamarket.orderservice.order.adapter.out.product;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.trustamarket.orderservice.order.application.port.out.ProductInfoCachePort;
+import com.trustamarket.orderservice.order.application.port.out.ProductInfoPort.ProductInfo;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * ProductInfoCachePort 의 Caffeine (in-JVM) 구현.
+ * pod 별 독립 cache — 분산 cache 필요 시 RedisProductInfoCache 추가 + @Primary 또는 @Profile 로 교체.
+ *
+ * TTL 30s — product.sold-out 같은 외부 이벤트 받아 evict 하면 race window 더 좁아짐.
+ */
+@Component
+public class CaffeineProductInfoCache implements ProductInfoCachePort {
+
+    private final Cache<UUID, ProductInfo> cache = Caffeine.newBuilder()
+            .maximumSize(10_000)
+            .expireAfterWrite(Duration.ofSeconds(30))
+            .build();
+
+    @Override
+    public Optional<ProductInfo> get(UUID productId) {
+        return Optional.ofNullable(cache.getIfPresent(productId));
+    }
+
+    @Override
+    public void put(UUID productId, ProductInfo info) {
+        cache.put(productId, info);
+    }
+
+    @Override
+    public void evict(UUID productId) {
+        cache.invalidate(productId);
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/product/ProductInfoFeignAdapter.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/product/ProductInfoFeignAdapter.java
@@ -1,6 +1,7 @@
 package com.trustamarket.orderservice.order.adapter.out.product;
 
 import com.trustamarket.common.response.CommonResponse;
+import com.trustamarket.orderservice.order.application.port.out.ProductInfoCachePort;
 import com.trustamarket.orderservice.order.application.port.out.ProductInfoPort;
 import com.trustamarket.orderservice.order.domain.exception.ProductLookupException;
 import feign.FeignException;
@@ -8,9 +9,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
 import java.util.UUID;
 
-// ProductInfoPort 구현 — Feign 호출 + CommonResponse unwrap + 통신 실패 변환.
+// ProductInfoPort 구현 — cache 우선 + miss 시 Feign 호출 + CommonResponse unwrap + 통신 실패 변환.
 // 404(상품 없음) / 5xx(통신 장애) 모두 ProductLookupException 으로 일원화.
 @Slf4j
 @Component
@@ -18,9 +20,20 @@ import java.util.UUID;
 public class ProductInfoFeignAdapter implements ProductInfoPort {
 
     private final ProductFeignClient feignClient;
+    private final ProductInfoCachePort cache;
 
     @Override
     public ProductInfo fetch(UUID productId) {
+        Optional<ProductInfo> cached = cache.get(productId);
+        if (cached.isPresent()) {
+            return cached.get();
+        }
+        ProductInfo info = fetchFromFeign(productId);
+        cache.put(productId, info);
+        return info;
+    }
+
+    private ProductInfo fetchFromFeign(UUID productId) {
         try {
             CommonResponse<ProductFeignClient.ProductInfoFeignResponse> resp =
                     feignClient.getProductInfo(productId);

--- a/src/main/java/com/trustamarket/orderservice/order/application/port/out/ProductInfoCachePort.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/port/out/ProductInfoCachePort.java
@@ -1,0 +1,21 @@
+package com.trustamarket.orderservice.order.application.port.out;
+
+import com.trustamarket.orderservice.order.application.port.out.ProductInfoPort.ProductInfo;
+
+import java.util.Optional;
+import java.util.UUID;
+
+// product-service 단건 응답을 in-JVM 으로 캐시. 1000 VU burst 시 같은 product 동시 조회 시
+// 첫 호출만 Feign 가고 나머지는 cache hit → product-service 부하 + connection hold 시간 감소.
+// 구현체 (Caffeine / Redis 등) 는 adapter/out/product 의 cache 어댑터에서 결정.
+public interface ProductInfoCachePort {
+
+    Optional<ProductInfo> get(UUID productId);
+
+    void put(UUID productId, ProductInfo info);
+
+    // product.sold-out / product.updated / product.deleted 등 외부 이벤트 받아 invalidate.
+    // TODO: order.product.sold-out Kafka listener 에서 evict 호출 (race window 30s → 거의 0 으로 좁힘).
+    //       현재는 TTL (30s) 만으로 stale 허용 — 결제 흐름 자체 영향 X (product-service 의 SOLD_OUT atomic UPDATE 가 oversell 방지).
+    void evict(UUID productId);
+}


### PR DESCRIPTION
## 🌱 설명

`CreateOrderService.createOrder()` 가 주문 생성 시 매번 product-service 로 Feign 호출 (`ProductInfoPort.fetch`). 1000 VU burst 부하 시 product-service 부담 + connection hold 누적.

product-service 의 `CaffeineProductCache` (latest endpoint) 와 동일 패턴으로 order-service 측에도 단건 product 정보 in-JVM cache 도입. 1000 buyer 가 같은 product 동시 주문 시 첫 호출만 Feign, 나머지 cache hit.

## 📌 관련 이슈

(없음 — 부하 개선)

## ✅ 주요 변경 사항

- `ProductInfoCachePort` (port) 추가 — 헥사고날 outbound port. get / put / evict.
- `CaffeineProductInfoCache` (adapter) 추가 — Caffeine in-JVM, TTL 30s / maxSize 10_000.
- `ProductInfoFeignAdapter` 수정 — cache 우선, miss 시 기존 Feign 호출 + cache put.
- `build.gradle` — Caffeine 의존성 추가 (product-service 와 동일 라이브러리).
- `evict()` 메소드에 TODO — `order.product.sold-out` Kafka listener 에서 호출하면 race window 거의 0 으로 좁힐 수 있음 (follow-up).

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치 생성
- [x] product-service `CaffeineProductCache` 와 동일 패턴 (port-adapter, 헥사고날)
- [x] 어려운 부분 (race window / TODO) 주석 추가
- [x] 셀프 리뷰
- [x] 전체 build / test 통과 (`./gradlew build`)

## 📚 추가 설명

### 정합성 trade-off (TTL 방식)

| 케이스 | 영향 |
|---|---|
| 새 product INSERT | cache miss → 첫 호출 시 Feign → cache put. 영향 X |
| price/status UPDATE | 최대 30s stale 가능 |
| DELETE | 30s 동안 cache 에 stale |

결제 흐름엔 영향 없음 — order create 시 server snapshot 으로 row 에 박히고, 이후 결제/배송은 자기 status 기반. oversell 방지는 product-service 의 atomic UPDATE (`WHERE status = 'ON_SALE'`) 가 책임.

### 분산 cache 로 확장

`@Primary` 또는 `@Profile` 로 `RedisProductInfoCache` 교체 가능 (포트 인터페이스 그대로).

### 예상 효과

1000 VU burst 시 같은 product 동시 호출 다수 → cache hit 으로 product-service 부담 + Feign latency 큰 폭 감소 예상. 부하 재측정으로 검증.