### PR TITLE
[fix] order create 의 save() → saveNew() (persist) 로 SELECT 1회 절감

### DIFF
--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/OrderJpaRepositoryAdapter.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/OrderJpaRepositoryAdapter.java
@@ -6,6 +6,8 @@ import com.trustamarket.orderservice.order.application.port.in.OrderSearchCriter
 import com.trustamarket.orderservice.order.domain.exception.OrderNotFoundException;
 import com.trustamarket.orderservice.order.domain.model.Order;
 import com.trustamarket.orderservice.order.domain.model.OrderId;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.criteria.Predicate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -27,15 +29,27 @@ public class OrderJpaRepositoryAdapter implements OrderRepository {
     private final OrderJpaRepository jpaRepository;
     private final OrderMapper mapper;
 
-    // TODO: PK가 도메인에서 미리 생성되고 mapper가 매번 새 entity를 만드는 패턴이라
-    //  JpaRepository.save()가 항상 merge() 타고 SELECT가 1회 추가
-    //  Persistable<UUID> 구현은 동일 트랜잭션 내 재저장 시 세션 충돌 발생
-    //  use case 흐름 정리되면서 함께 최적화 (findById → 도메인 행위 → 트랜잭션 dirty checking 패턴 검토)
+    // EntityManager 는 @PersistenceContext 로 field injection (RequiredArgsConstructor 와 호환).
+    // saveNew() 에서 persist() 직접 호출 시 사용.
+    @PersistenceContext
+    private EntityManager em;
+
+    // 기존 entity merge — findById 로 가져온 managed entity 갱신 시 사용.
+    // 신규 INSERT 시엔 saveNew() 사용 (SELECT 1회 절감).
     @Override
     public Order save(Order order) {
         OrderJpaEntity entity = mapper.toEntity(order);
         OrderJpaEntity saved = jpaRepository.save(entity);
         return mapper.toDomain(saved);
+    }
+
+    // 신규 entity 명시적 persist — JpaRepository.save() 의 merge 경로 (SELECT 1회) 회피.
+    // PK 가 도메인에서 미리 생성 (OrderId.generate) 되어 detached 가 아니라 new 임이 보장됨.
+    @Override
+    public Order saveNew(Order order) {
+        OrderJpaEntity entity = mapper.toEntity(order);
+        em.persist(entity);
+        return mapper.toDomain(entity);
     }
 
     @Override

--- a/src/main/java/com/trustamarket/orderservice/order/application/port/out/OrderRepository.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/port/out/OrderRepository.java
@@ -14,7 +14,15 @@ import java.util.UUID;
 public interface OrderRepository {
 
     // Command
+
+    // 기존 entity 업데이트 (merge — JPA 가 SELECT 후 변경 여부 판단 → UPDATE 또는 INSERT).
+    // findById 로 가져온 managed entity 갱신에 사용.
     Order save(Order order);
+
+    // 신규 entity 명시적 INSERT (persist — SELECT skip).
+    // PK 가 도메인에서 미리 생성 (OrderId.generate) 되는 케이스만 안전.
+    // 사용처: CreateOrderService 의 신규 주문 INSERT.
+    Order saveNew(Order order);
 
     Optional<Order> findById(OrderId id);
 

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/command/CreateOrderService.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/command/CreateOrderService.java
@@ -44,7 +44,9 @@ public class CreateOrderService implements CreateOrderUseCase {
                     cmd.type(),
                     Money.of(cmd.shippingFee())
             );
-            Order saved = orderRepository.save(order);
+            // 신규 주문 — PK 가 Order.create() 시점에 OrderId.generate() 로 미리 생성됨.
+            // saveNew() 사용해서 JpaRepository.save() 의 merge 경로 (SELECT 1회) 회피.
+            Order saved = orderRepository.saveNew(order);
             historyRecorder.record(saved.getId(), null, OrderStatus.REQUESTED, null);
             return CreateOrderResult.from(saved);
         });

--- a/src/test/java/com/trustamarket/orderservice/order/application/service/command/CreateOrderServiceTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/application/service/command/CreateOrderServiceTest.java
@@ -65,7 +65,7 @@ class CreateOrderServiceTest {
         );
         when(productInfoPort.fetch(productId)).thenReturn(
                 new ProductInfo(productId, sellerId, "정공-상품명", 100_000L, "ON_SALE"));
-        when(orderRepository.save(any(Order.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(orderRepository.saveNew(any(Order.class))).thenAnswer(inv -> inv.getArgument(0));
 
         CreateOrderResult result = service.createOrder(cmd);
 
@@ -76,7 +76,7 @@ class CreateOrderServiceTest {
 
         // server snapshot 우선 검증 — sellerId / productName / productPrice 모두 product-service 진실값 사용 (client 입력 무시)
         ArgumentCaptor<Order> captor = ArgumentCaptor.forClass(Order.class);
-        verify(orderRepository).save(captor.capture());
+        verify(orderRepository).saveNew(captor.capture());
         Order saved = captor.getValue();
         assertThat(saved.getSeller().id()).isEqualTo(sellerId);          // ProductInfo 의 sellerId
         assertThat(saved.getProduct().name()).isEqualTo("정공-상품명");    // ProductInfo 의 name (cmd 의 "client-claim-name" 아님)
@@ -100,6 +100,6 @@ class CreateOrderServiceTest {
         assertThatThrownBy(() -> service.createOrder(cmd))
                 .isInstanceOf(ProductNotPurchasableException.class);
 
-        verify(orderRepository, never()).save(any(Order.class));
+        verify(orderRepository, never()).saveNew(any(Order.class));
     }
 }


### PR DESCRIPTION
## 🌱 설명

`CreateOrderService` 가 신규 주문 INSERT 시 `JpaRepository.save()` 호출. JPA spec 상 save() 는 merge 경로 — entity 가 detached 일 수 있어 **항상 SELECT 1회 선행 후 INSERT/UPDATE** 판단.

PK 는 도메인에서 `OrderId.generate()` 로 미리 생성되어 항상 신규 entity 임이 보장됨. → `EntityManager.persist()` 직접 호출로 SELECT skip 가능.

코드 주석에 명시된 TODO 일부 해결.

## 📌 관련 이슈

(없음 — 부하 개선)

## ✅ 주요 변경 사항

- `OrderRepository` port — `saveNew(Order)` 메소드 추가 (신규 entity 명시적 persist)
- `OrderJpaRepositoryAdapter` — `EntityManager` field injection (`@PersistenceContext`) + `saveNew()` 구현 (`em.persist()` 직접 호출)
- `CreateOrderService` — `save()` → `saveNew()`. 신규 주문이라 명시적 분리.
- `CreateOrderServiceTest` — mock + verify 를 `saveNew` 로 갱신

기존 `save()` (merge) 는 `RequestPaymentService` 등 findById 로 가져온 managed entity 갱신용으로 그대로 유지.

## 📝 체크리스트

- [x] develop 브랜치 기준
- [x] 헥사고날 port 분리 유지 (`saveNew` 도 port interface 에 명시)
- [x] 어려운 부분 (merge vs persist 차이 + 사용 가이드라인) 주석 추가
- [x] 셀프 리뷰
- [x] 전체 184 tests 통과 (`./gradlew build`)

## 📚 추가 설명

### Persistable<UUID> 구현 안 한 이유

기존 TODO 주석에 명시:
> Persistable<UUID> 구현은 동일 트랜잭션 내 재저장 시 세션 충돌 발생

→ `saveNew()` 분리가 더 명시적 + 안전 (호출자가 신규 / 기존 구분).

### 예상 효과

- 1000 iter × ~3-5ms SELECT = **~3-5초 wall-clock 절감**
- DB load 감소 (Cloud SQL SELECT 1000건/run 제거)
- 부하 재측정으로 검증

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **리팩토링**
  * 새 주문 생성 시 저장 프로세스를 최적화했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/order-service/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->