### PR TITLE
refactor: ResponseEntity<CommonResponse<T>> 통일

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -20,6 +20,14 @@ spec:
         app: order-service
     spec:
       automountServiceAccountToken: false
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: Exists
+              topologyKey: kubernetes.io/hostname
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/in/web/OrderCommandController.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/in/web/OrderCommandController.java
@@ -2,6 +2,7 @@ package com.trustamarket.orderservice.order.adapter.in.web;
 
 import com.trustamarket.common.config.security.UserDetailsImpl;
 import com.trustamarket.common.util.SecurityUtil;
+import com.trustamarket.common.response.CommonResponse;
 import com.trustamarket.orderservice.order.adapter.in.web.dto.request.CancelOrderRequest;
 import com.trustamarket.orderservice.order.adapter.in.web.dto.request.CreateOrderRequest;
 import com.trustamarket.orderservice.order.adapter.in.web.dto.request.DecideReturnRequest;
@@ -18,13 +19,13 @@ import com.trustamarket.orderservice.order.application.port.in.RequestReturnUseC
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
@@ -45,56 +46,56 @@ public class OrderCommandController {
     private final DecideReturnUseCase decideReturnUseCase;
 
     @PostMapping("/api/v1/orders")
-    @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("hasRole('MEMBER')")
-    public CreateOrderResponse create(@Valid @RequestBody CreateOrderRequest request) {
+    public ResponseEntity<CommonResponse<CreateOrderResponse>> create(@Valid @RequestBody CreateOrderRequest request) {
         UserDetailsImpl me = currentUser();
-        return CreateOrderResponse.from(
+        CreateOrderResponse result = CreateOrderResponse.from(
                 createOrderUseCase.createOrder(request.toCommand(me.getUuid(), me.getName()))
         );
+        return ResponseEntity.status(HttpStatus.CREATED).body(CommonResponse.of(201, result));
     }
 
     @PostMapping("/api/v1/orders/{orderId}/payments")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasRole('MEMBER')")
-    public void requestPayment(
+    public ResponseEntity<Void> requestPayment(
             @PathVariable UUID orderId,
             @RequestHeader("Idempotency-Key") String idempotencyKey
     ) {
         UUID buyerId = SecurityUtil.getCurrentUserIdOrThrow();
         requestPaymentUseCase.requestPayment(new RequestPaymentCommand(orderId, buyerId, idempotencyKey));
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/api/v1/orders/{orderId}/cancellations")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasAnyRole('MEMBER','ADMIN')")
-    public void cancel(@PathVariable UUID orderId, @Valid @RequestBody CancelOrderRequest request) {
+    public ResponseEntity<Void> cancel(@PathVariable UUID orderId, @Valid @RequestBody CancelOrderRequest request) {
         UUID actorId = SecurityUtil.getCurrentUserIdOrThrow();
         cancelOrderUseCase.cancel(request.toCommand(orderId, actorId));
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/api/v1/orders/{orderId}/confirmations")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasRole('MEMBER')")
-    public void confirm(@PathVariable UUID orderId) {
+    public ResponseEntity<Void> confirm(@PathVariable UUID orderId) {
         UUID buyerId = SecurityUtil.getCurrentUserIdOrThrow();
         confirmOrderUseCase.confirm(new ConfirmOrderCommand(orderId, buyerId));
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/api/v1/orders/{orderId}/returns")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasRole('MEMBER')")
-    public void requestReturn(@PathVariable UUID orderId, @Valid @RequestBody RequestReturnRequest request) {
+    public ResponseEntity<Void> requestReturn(@PathVariable UUID orderId, @Valid @RequestBody RequestReturnRequest request) {
         UUID buyerId = SecurityUtil.getCurrentUserIdOrThrow();
         requestReturnUseCase.requestReturn(request.toCommand(orderId, buyerId));
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/api/v1/admin/orders/{orderId}/returns/decisions")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasRole('ADMIN')")
-    public void decideReturn(@PathVariable UUID orderId, @Valid @RequestBody DecideReturnRequest request) {
+    public ResponseEntity<Void> decideReturn(@PathVariable UUID orderId, @Valid @RequestBody DecideReturnRequest request) {
         UUID adminId = SecurityUtil.getCurrentUserIdOrThrow();
         decideReturnUseCase.decide(request.toCommand(orderId, adminId));
+        return ResponseEntity.noContent().build();
     }
 
     // SecurityContext 에서 UserDetailsImpl 까지 직접 꺼내야 하는 경우 (createOrder 의 buyerName 등)

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/in/web/OrderCommandController.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/in/web/OrderCommandController.java
@@ -17,6 +17,7 @@ import com.trustamarket.orderservice.order.application.port.in.RequestPaymentUse
 import com.trustamarket.orderservice.order.application.port.in.RequestPaymentUseCase.RequestPaymentCommand;
 import com.trustamarket.orderservice.order.application.port.in.RequestReturnUseCase;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -59,7 +60,7 @@ public class OrderCommandController {
     @PreAuthorize("hasRole('MEMBER')")
     public ResponseEntity<Void> requestPayment(
             @PathVariable UUID orderId,
-            @RequestHeader("Idempotency-Key") String idempotencyKey
+            @RequestHeader("Idempotency-Key") @NotBlank String idempotencyKey
     ) {
         UUID buyerId = SecurityUtil.getCurrentUserIdOrThrow();
         requestPaymentUseCase.requestPayment(new RequestPaymentCommand(orderId, buyerId, idempotencyKey));

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/in/web/OrderCommandController.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/in/web/OrderCommandController.java
@@ -21,6 +21,7 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -37,6 +38,7 @@ import java.util.UUID;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping
+@Validated
 public class OrderCommandController {
 
     private final CreateOrderUseCase createOrderUseCase;

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/in/web/OrderQueryController.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/in/web/OrderQueryController.java
@@ -1,5 +1,7 @@
 package com.trustamarket.orderservice.order.adapter.in.web;
 
+import com.trustamarket.common.response.CommonResponse;
+import com.trustamarket.common.response.PagedResponse;
 import com.trustamarket.common.util.SecurityUtil;
 import com.trustamarket.orderservice.order.adapter.in.web.dto.response.OrderDetailResponse;
 import com.trustamarket.orderservice.order.adapter.in.web.dto.response.OrderStatusHistoryResponse;
@@ -21,6 +23,7 @@ import com.trustamarket.orderservice.order.domain.model.OrderStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -50,49 +53,54 @@ public class OrderQueryController {
     // 본인이 buyer 또는 seller로 참여한 모든 주문
     @GetMapping("/api/v1/orders/me")
     @PreAuthorize("hasRole('MEMBER')")
-    public Page<OrderSummaryResponse> getMyOrders(Pageable pageable) {
+    public ResponseEntity<PagedResponse<OrderSummaryResponse>> getMyOrders(Pageable pageable) {
         UUID actorId = SecurityUtil.getCurrentUserIdOrThrow();
-        return getMyOrdersUseCase.getMyOrders(new GetMyOrdersQuery(actorId, pageable))
+        Page<OrderSummaryResponse> page = getMyOrdersUseCase.getMyOrders(new GetMyOrdersQuery(actorId, pageable))
                 .map(OrderSummaryResponse::from);
+        return ResponseEntity.ok(PagedResponse.of(200, page));
     }
 
     @GetMapping("/api/v1/orders/me/purchases")
     @PreAuthorize("hasRole('MEMBER')")
-    public Page<OrderSummaryResponse> getMyPurchases(Pageable pageable) {
+    public ResponseEntity<PagedResponse<OrderSummaryResponse>> getMyPurchases(Pageable pageable) {
         UUID buyerId = SecurityUtil.getCurrentUserIdOrThrow();
-        return getMyPurchasesUseCase.getMyPurchases(new GetMyPurchasesQuery(buyerId, pageable))
+        Page<OrderSummaryResponse> page = getMyPurchasesUseCase.getMyPurchases(new GetMyPurchasesQuery(buyerId, pageable))
                 .map(OrderSummaryResponse::from);
+        return ResponseEntity.ok(PagedResponse.of(200, page));
     }
 
     @GetMapping("/api/v1/orders/me/sales")
     @PreAuthorize("hasRole('MEMBER')")
-    public Page<OrderSummaryResponse> getMySales(Pageable pageable) {
+    public ResponseEntity<PagedResponse<OrderSummaryResponse>> getMySales(Pageable pageable) {
         UUID sellerId = SecurityUtil.getCurrentUserIdOrThrow();
-        return getMySalesUseCase.getMySales(new GetMySalesQuery(sellerId, pageable))
+        Page<OrderSummaryResponse> page = getMySalesUseCase.getMySales(new GetMySalesQuery(sellerId, pageable))
                 .map(OrderSummaryResponse::from);
+        return ResponseEntity.ok(PagedResponse.of(200, page));
     }
 
     // 단건 상세 — buyer 또는 seller 본인만 (application 레이어 OrderAccessGuard 가 검증)
     @GetMapping("/api/v1/orders/{orderId}")
     @PreAuthorize("hasRole('MEMBER')")
-    public OrderDetailResponse getOrder(@PathVariable UUID orderId) {
+    public ResponseEntity<CommonResponse<OrderDetailResponse>> getOrder(@PathVariable UUID orderId) {
         UUID actorId = SecurityUtil.getCurrentUserIdOrThrow();
-        return OrderDetailResponse.from(
+        OrderDetailResponse result = OrderDetailResponse.from(
                 getOrderUseCase.getOrder(new GetOrderQuery(orderId, actorId))
         );
+        return ResponseEntity.ok(CommonResponse.of(200, result));
     }
 
     @GetMapping("/api/v1/admin/orders")
     @PreAuthorize("hasRole('ADMIN')")
-    public Page<OrderSummaryResponse> list(Pageable pageable) {
-        return listOrdersUseCase.list(pageable).map(OrderSummaryResponse::from);
+    public ResponseEntity<PagedResponse<OrderSummaryResponse>> list(Pageable pageable) {
+        Page<OrderSummaryResponse> page = listOrdersUseCase.list(pageable).map(OrderSummaryResponse::from);
+        return ResponseEntity.ok(PagedResponse.of(200, page));
     }
 
     // 검색 — status/기간/buyerName 부분일치 (모두 nullable)
     // criteria record 의 compact constructor 가 fromDate>toDate 차단 + buyerName blank 정규화
     @GetMapping("/api/v1/admin/orders/search")
     @PreAuthorize("hasRole('ADMIN')")
-    public Page<OrderSummaryResponse> search(
+    public ResponseEntity<PagedResponse<OrderSummaryResponse>> search(
             @RequestParam(required = false) OrderStatus status,
             @RequestParam(required = false) Instant fromDate,
             @RequestParam(required = false) Instant toDate,
@@ -100,15 +108,17 @@ public class OrderQueryController {
             Pageable pageable
     ) {
         OrderSearchCriteria criteria = new OrderSearchCriteria(status, fromDate, toDate, buyerName);
-        return searchOrdersUseCase.search(new SearchOrdersQuery(criteria, pageable))
+        Page<OrderSummaryResponse> page = searchOrdersUseCase.search(new SearchOrdersQuery(criteria, pageable))
                 .map(OrderSummaryResponse::from);
+        return ResponseEntity.ok(PagedResponse.of(200, page));
     }
 
     @GetMapping("/api/v1/admin/orders/{orderId}/status-histories")
     @PreAuthorize("hasRole('ADMIN')")
-    public List<OrderStatusHistoryResponse> getStatusHistory(@PathVariable UUID orderId) {
-        return getStatusHistoryUseCase.getHistory(orderId).stream()
+    public ResponseEntity<CommonResponse<List<OrderStatusHistoryResponse>>> getStatusHistory(@PathVariable UUID orderId) {
+        List<OrderStatusHistoryResponse> list = getStatusHistoryUseCase.getHistory(orderId).stream()
                 .map(OrderStatusHistoryResponse::from)
                 .toList();
+        return ResponseEntity.ok(CommonResponse.of(200, list));
     }
 }

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/product/ProductFeignClient.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/product/ProductFeignClient.java
@@ -2,6 +2,7 @@ package com.trustamarket.orderservice.order.adapter.out.product;
 
 import com.trustamarket.common.response.CommonResponse;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
@@ -13,7 +14,7 @@ import java.util.UUID;
 public interface ProductFeignClient {
 
     @GetMapping("/internal/v1/products/{productId}")
-    CommonResponse<ProductInfoFeignResponse> getProductInfo(@PathVariable UUID productId);
+    ResponseEntity<CommonResponse<ProductInfoFeignResponse>> getProductInfo(@PathVariable UUID productId);
 
     // product-service 의 ProductInfoResponse 와 1:1 매칭 (필드명/순서/타입).
     // price 는 product-service 가 Integer — order 측은 long 받음 (자동 widening).

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/product/ProductInfoFeignAdapter.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/product/ProductInfoFeignAdapter.java
@@ -6,6 +6,7 @@ import com.trustamarket.orderservice.order.domain.exception.ProductLookupExcepti
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
@@ -22,12 +23,12 @@ public class ProductInfoFeignAdapter implements ProductInfoPort {
     @Override
     public ProductInfo fetch(UUID productId) {
         try {
-            CommonResponse<ProductFeignClient.ProductInfoFeignResponse> resp =
+            ResponseEntity<CommonResponse<ProductFeignClient.ProductInfoFeignResponse>> resp =
                     feignClient.getProductInfo(productId);
-            if (resp == null || resp.data() == null) {
+            if (resp.getBody() == null || resp.getBody().data() == null) {
                 throw new ProductLookupException(productId);
             }
-            ProductFeignClient.ProductInfoFeignResponse data = resp.data();
+            ProductFeignClient.ProductInfoFeignResponse data = resp.getBody().data();
             // 외부 응답 엄격 검증 — 필수 필드 누락/비정상 시 fail-fast (금액 0 변환 같은 silent corruption 차단)
             if (data.id() == null
                     || !productId.equals(data.id())

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/product/ProductInfoFeignAdapter.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/product/ProductInfoFeignAdapter.java
@@ -25,7 +25,7 @@ public class ProductInfoFeignAdapter implements ProductInfoPort {
         try {
             ResponseEntity<CommonResponse<ProductFeignClient.ProductInfoFeignResponse>> resp =
                     feignClient.getProductInfo(productId);
-            if (resp.getBody() == null || resp.getBody().data() == null) {
+            if (resp == null || resp.getBody() == null || resp.getBody().data() == null) {
                 throw new ProductLookupException(productId);
             }
             ProductFeignClient.ProductInfoFeignResponse data = resp.getBody().data();

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletFeignClient.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletFeignClient.java
@@ -2,6 +2,7 @@ package com.trustamarket.orderservice.order.adapter.out.wallet;
 
 import com.trustamarket.common.response.CommonResponse;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -13,7 +14,7 @@ import java.util.UUID;
 public interface WalletFeignClient {
 
     @PatchMapping("/internal/v1/wallets/usages")
-    CommonResponse<UseWalletResponse> usePoint(@RequestBody UseWalletRequest request);
+    ResponseEntity<CommonResponse<UseWalletResponse>> usePoint(@RequestBody UseWalletRequest request);
 
     // wallet-service 의 UseWalletRequest 와 동일 필드명/타입.
     record UseWalletRequest(

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletPaymentAdapter.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletPaymentAdapter.java
@@ -6,6 +6,7 @@ import com.trustamarket.orderservice.order.domain.exception.WalletCommunicationE
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
 // WalletPaymentPort 실 구현 — Feign 으로 wallet-service 의 /internal/v1/wallets/usages 호출.
@@ -21,14 +22,14 @@ public class WalletPaymentAdapter implements WalletPaymentPort {
     @Override
     public DeductPointResponse deduct(DeductPointRequest request) {
         try {
-            CommonResponse<WalletFeignClient.UseWalletResponse> response = walletFeignClient.usePoint(
+            ResponseEntity<CommonResponse<WalletFeignClient.UseWalletResponse>> response = walletFeignClient.usePoint(
                     new WalletFeignClient.UseWalletRequest(
                             request.orderId(),
                             request.buyerId(),
                             request.totalAmount()
                     )
             );
-            WalletFeignClient.UseWalletResponse data = response.data();
+            WalletFeignClient.UseWalletResponse data = response.getBody() != null ? response.getBody().data() : null;
             if (data == null) {
                 log.error("[Wallet] 빈 응답 — orderId={}", request.orderId());
                 throw new WalletCommunicationException();

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletPaymentAdapter.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletPaymentAdapter.java
@@ -29,9 +29,15 @@ public class WalletPaymentAdapter implements WalletPaymentPort {
                             request.totalAmount()
                     )
             );
-            WalletFeignClient.UseWalletResponse data = response.getBody() != null ? response.getBody().data() : null;
-            if (data == null) {
-                log.error("[Wallet] 빈 응답 — orderId={}", request.orderId());
+            CommonResponse<WalletFeignClient.UseWalletResponse> body =
+                    response != null ? response.getBody() : null;
+            WalletFeignClient.UseWalletResponse data =
+                    body != null ? body.data() : null;
+            if (data == null
+                    || data.balance() == null
+                    || data.balance() < 0L
+                    || (data.shortage() != null && data.shortage() < 0L)) {
+                log.error("[Wallet] 빈/비정상 응답 — orderId={}", request.orderId());
                 throw new WalletCommunicationException();
             }
             return new DeductPointResponse(data.balance(), data.shortage());

--- a/src/test/java/com/trustamarket/orderservice/order/adapter/out/product/ProductInfoFeignAdapterTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/adapter/out/product/ProductInfoFeignAdapterTest.java
@@ -1,0 +1,66 @@
+package com.trustamarket.orderservice.order.adapter.out.product;
+
+import com.trustamarket.common.response.CommonResponse;
+import com.trustamarket.orderservice.order.application.port.out.ProductInfoPort.ProductInfo;
+import com.trustamarket.orderservice.order.domain.exception.ProductLookupException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProductInfoFeignAdapterTest {
+
+    @Mock ProductFeignClient feignClient;
+    @InjectMocks ProductInfoFeignAdapter adapter;
+
+    @Test
+    @DisplayName("정상 응답 — ResponseEntity<CommonResponse<T>> unwrap")
+    void fetch_success() {
+        UUID productId = UUID.randomUUID();
+        UUID sellerId = UUID.randomUUID();
+        var feignResp = new ProductFeignClient.ProductInfoFeignResponse(
+                productId, sellerId, "테스트 상품", 100_000L, "ON_SALE");
+        when(feignClient.getProductInfo(productId))
+                .thenReturn(ResponseEntity.ok(CommonResponse.of(200, feignResp)));
+
+        ProductInfo result = adapter.fetch(productId);
+
+        assertThat(result.id()).isEqualTo(productId);
+        assertThat(result.sellerId()).isEqualTo(sellerId);
+        assertThat(result.name()).isEqualTo("테스트 상품");
+        assertThat(result.price()).isEqualTo(100_000L);
+        assertThat(result.status()).isEqualTo("ON_SALE");
+    }
+
+    @Test
+    @DisplayName("body null — ProductLookupException")
+    void fetch_nullBody() {
+        UUID productId = UUID.randomUUID();
+        when(feignClient.getProductInfo(productId))
+                .thenReturn(ResponseEntity.ok(null));
+
+        assertThatThrownBy(() -> adapter.fetch(productId))
+                .isInstanceOf(ProductLookupException.class);
+    }
+
+    @Test
+    @DisplayName("data null — ProductLookupException")
+    void fetch_nullData() {
+        UUID productId = UUID.randomUUID();
+        when(feignClient.getProductInfo(productId))
+                .thenReturn(ResponseEntity.ok(CommonResponse.of(200, null)));
+
+        assertThatThrownBy(() -> adapter.fetch(productId))
+                .isInstanceOf(ProductLookupException.class);
+    }
+}

--- a/src/test/java/com/trustamarket/orderservice/order/adapter/out/product/ProductInfoFeignAdapterTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/adapter/out/product/ProductInfoFeignAdapterTest.java
@@ -43,6 +43,17 @@ class ProductInfoFeignAdapterTest {
     }
 
     @Test
+    @DisplayName("ResponseEntity 자체 null — ProductLookupException")
+    void fetch_nullResponse() {
+        UUID productId = UUID.randomUUID();
+        when(feignClient.getProductInfo(productId))
+                .thenReturn(null);
+
+        assertThatThrownBy(() -> adapter.fetch(productId))
+                .isInstanceOf(ProductLookupException.class);
+    }
+
+    @Test
     @DisplayName("body null — ProductLookupException")
     void fetch_nullBody() {
         UUID productId = UUID.randomUUID();

--- a/src/test/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletPaymentAdapterTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletPaymentAdapterTest.java
@@ -41,6 +41,16 @@ class WalletPaymentAdapterTest {
     }
 
     @Test
+    @DisplayName("ResponseEntity 자체 null — WalletCommunicationException")
+    void deduct_nullResponse() {
+        when(walletFeignClient.usePoint(any()))
+                .thenReturn(null);
+
+        assertThatThrownBy(() -> adapter.deduct(new DeductPointRequest(UUID.randomUUID(), UUID.randomUUID(), 100L)))
+                .isInstanceOf(WalletCommunicationException.class);
+    }
+
+    @Test
     @DisplayName("body null — WalletCommunicationException")
     void deduct_nullBody() {
         when(walletFeignClient.usePoint(any()))
@@ -55,6 +65,28 @@ class WalletPaymentAdapterTest {
     void deduct_nullData() {
         when(walletFeignClient.usePoint(any()))
                 .thenReturn(ResponseEntity.ok(CommonResponse.of(200, null)));
+
+        assertThatThrownBy(() -> adapter.deduct(new DeductPointRequest(UUID.randomUUID(), UUID.randomUUID(), 100L)))
+                .isInstanceOf(WalletCommunicationException.class);
+    }
+
+    @Test
+    @DisplayName("음수 balance — WalletCommunicationException")
+    void deduct_negativeBalance() {
+        var walletResp = new WalletFeignClient.UseWalletResponse(-100L, null);
+        when(walletFeignClient.usePoint(any()))
+                .thenReturn(ResponseEntity.ok(CommonResponse.of(200, walletResp)));
+
+        assertThatThrownBy(() -> adapter.deduct(new DeductPointRequest(UUID.randomUUID(), UUID.randomUUID(), 100L)))
+                .isInstanceOf(WalletCommunicationException.class);
+    }
+
+    @Test
+    @DisplayName("음수 shortage — WalletCommunicationException")
+    void deduct_negativeShortage() {
+        var walletResp = new WalletFeignClient.UseWalletResponse(0L, -500L);
+        when(walletFeignClient.usePoint(any()))
+                .thenReturn(ResponseEntity.ok(CommonResponse.of(200, walletResp)));
 
         assertThatThrownBy(() -> adapter.deduct(new DeductPointRequest(UUID.randomUUID(), UUID.randomUUID(), 100L)))
                 .isInstanceOf(WalletCommunicationException.class);

--- a/src/test/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletPaymentAdapterTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletPaymentAdapterTest.java
@@ -1,0 +1,62 @@
+package com.trustamarket.orderservice.order.adapter.out.wallet;
+
+import com.trustamarket.common.response.CommonResponse;
+import com.trustamarket.orderservice.order.application.port.out.WalletPaymentPort.DeductPointRequest;
+import com.trustamarket.orderservice.order.application.port.out.WalletPaymentPort.DeductPointResponse;
+import com.trustamarket.orderservice.order.domain.exception.WalletCommunicationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WalletPaymentAdapterTest {
+
+    @Mock WalletFeignClient walletFeignClient;
+    @InjectMocks WalletPaymentAdapter adapter;
+
+    @Test
+    @DisplayName("정상 차감 — ResponseEntity<CommonResponse<T>> unwrap")
+    void deduct_success() {
+        UUID orderId = UUID.randomUUID();
+        UUID buyerId = UUID.randomUUID();
+        var walletResp = new WalletFeignClient.UseWalletResponse(9_500_000L, null);
+        when(walletFeignClient.usePoint(any()))
+                .thenReturn(ResponseEntity.ok(CommonResponse.of(200, walletResp)));
+
+        DeductPointResponse result = adapter.deduct(new DeductPointRequest(orderId, buyerId, 500_000L));
+
+        assertThat(result.balance()).isEqualTo(9_500_000L);
+        assertThat(result.shortage()).isNull();
+    }
+
+    @Test
+    @DisplayName("body null — WalletCommunicationException")
+    void deduct_nullBody() {
+        when(walletFeignClient.usePoint(any()))
+                .thenReturn(ResponseEntity.ok(null));
+
+        assertThatThrownBy(() -> adapter.deduct(new DeductPointRequest(UUID.randomUUID(), UUID.randomUUID(), 100L)))
+                .isInstanceOf(WalletCommunicationException.class);
+    }
+
+    @Test
+    @DisplayName("data null — WalletCommunicationException")
+    void deduct_nullData() {
+        when(walletFeignClient.usePoint(any()))
+                .thenReturn(ResponseEntity.ok(CommonResponse.of(200, null)));
+
+        assertThatThrownBy(() -> adapter.deduct(new DeductPointRequest(UUID.randomUUID(), UUID.randomUUID(), 100L)))
+                .isInstanceOf(WalletCommunicationException.class);
+    }
+}


### PR DESCRIPTION
## 🌱 설명

controller (inbound) + feign client (outbound) 반환 타입을 ResponseEntity<CommonResponse<T>> 로 통일. 헤더 직접 제어 가능하게.

## 📌 관련 이슈

close #

## ✅ 주요 변경 사항

- OrderCommandController — @ResponseStatus 제거, ResponseEntity<CommonResponse<T>> / ResponseEntity<Void>
- OrderQueryController — Page → ResponseEntity<PagedResponse<T>>, raw DTO → ResponseEntity<CommonResponse<T>>
- ProductFeignClient / WalletFeignClient — CommonResponse<T> → ResponseEntity<CommonResponse<T>>
- ProductInfoFeignAdapter / WalletPaymentAdapter — resp.getBody().data() unwrap
- Feign adapter 단위 테스트 추가 (ProductInfoFeignAdapterTest, WalletPaymentAdapterTest)

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

- 응답 형식 / HTTP 상태 코드 변경 없음 (CommonResponseAdvice 가 이중 래핑 방지)
- product-service / wallet-service 코드 수정 없음 (order-service 쪽만)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * API 응답을 표준화하여 HTTP 상태 코드와 공통 응답 포맷으로 일괄 반환하고 일부 요청에 유효성 검증을 추가함.

* **Tests**
  * 외부 서비스(상품/지갑) 응답 언래핑 및 오류 흐름을 검증하는 단위 테스트 추가.

* **Chores**
  * 배포 설정에 파드 안티어피니티를 적용해 동일 호스트에 중복 배치되지 않도록 제약 추가.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/order-service/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->