### PR TITLE
feat: payment saga 결과 재확인 + DB queue 백오프 재시도 (#56)

### DIFF
--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/notification/NotificationFeignClient.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/notification/NotificationFeignClient.java
@@ -1,0 +1,35 @@
+package com.trustamarket.orderservice.order.adapter.out.notification;
+
+import com.trustamarket.common.response.CommonResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+// notification-service 의 AlertManager 포맷 webhook 호출용.
+// reconciliation 의 GIVEN_UP 알림을 Discord 로 전달.
+@FeignClient(name = "notification-service")
+public interface NotificationFeignClient {
+
+    @PostMapping("/api/v1/alerts/webhook")
+    ResponseEntity<CommonResponse<Void>> send(@RequestBody AlertManagerWebhookPayload payload);
+
+    // notification-service 의 AlertManagerWebhookRequest 와 동일 필드.
+    record AlertManagerWebhookPayload(
+            String version,
+            String status,
+            Map<String, String> commonLabels,
+            List<AlertItem> alerts
+    ) {
+        public record AlertItem(
+                String status,
+                Map<String, String> labels,
+                Map<String, String> annotations,
+                OffsetDateTime startsAt
+        ) {}
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/notification/ReconciliationAlertAdapter.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/notification/ReconciliationAlertAdapter.java
@@ -1,0 +1,56 @@
+package com.trustamarket.orderservice.order.adapter.out.notification;
+
+import com.trustamarket.orderservice.order.application.port.out.ReconciliationAlertPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+// reconciliation 의 GIVEN_UP 알림을 notification-service 의 AlertManager webhook 으로 전달.
+// Discord 발송은 notification-service 내부 strategy 가 처리.
+// 발송 실패는 caller (Processor) 가 catch — best-effort.
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReconciliationAlertAdapter implements ReconciliationAlertPort {
+
+    private static final String ALERT_NAME = "payment-reconciliation-given-up";
+    private static final String SEVERITY = "critical";
+
+    private final NotificationFeignClient feignClient;
+
+    @Override
+    public void notifyGivenUp(UUID orderId, int retryCount, String lastError) {
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put("alertname", ALERT_NAME);
+        labels.put("severity", SEVERITY);
+        labels.put("service", "order-service");
+        labels.put("orderId", orderId.toString());
+        labels.put("retryCount", Integer.toString(retryCount));
+
+        Map<String, String> annotations = new LinkedHashMap<>();
+        annotations.put("summary", "결제 결과 확인 재시도 한도 도달 — 수동 처리 필요");
+        annotations.put("description", lastError != null ? lastError : "");
+
+        var item = new NotificationFeignClient.AlertManagerWebhookPayload.AlertItem(
+                "firing",
+                labels,
+                annotations,
+                OffsetDateTime.now()
+        );
+        var payload = new NotificationFeignClient.AlertManagerWebhookPayload(
+                "4",
+                "firing",
+                Map.of("severity", SEVERITY),
+                List.of(item)
+        );
+        feignClient.send(payload);
+        log.info("[ReconciliationAlert] GIVEN_UP 알림 발송 — orderId={}, retryCount={}",
+                orderId, retryCount);
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/reconciliation/PaymentReconciliationJpaEntity.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/reconciliation/PaymentReconciliationJpaEntity.java
@@ -8,6 +8,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -48,6 +49,11 @@ public class PaymentReconciliationJpaEntity extends BaseUserEntity {
 
     @Column(name = "last_error", columnDefinition = "text")
     private String lastError;
+
+    // Optimistic Lock — Hibernate 가 UPDATE 시 자동 증가, 충돌 시 OptimisticLockException.
+    @Version
+    @Column(name = "version", nullable = false)
+    private long version;
 
     @Builder
     private PaymentReconciliationJpaEntity(UUID id, UUID orderId, ReconciliationStatus status,

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/reconciliation/PaymentReconciliationJpaEntity.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/reconciliation/PaymentReconciliationJpaEntity.java
@@ -58,7 +58,7 @@ public class PaymentReconciliationJpaEntity extends BaseUserEntity {
     @Builder
     private PaymentReconciliationJpaEntity(UUID id, UUID orderId, ReconciliationStatus status,
                                            int retryCount, Instant nextRetryAt,
-                                           Instant lastAttemptAt, String lastError) {
+                                           Instant lastAttemptAt, String lastError, long version) {
         this.id = id;
         this.orderId = orderId;
         this.status = status;
@@ -66,5 +66,6 @@ public class PaymentReconciliationJpaEntity extends BaseUserEntity {
         this.nextRetryAt = nextRetryAt;
         this.lastAttemptAt = lastAttemptAt;
         this.lastError = lastError;
+        this.version = version;
     }
 }

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/reconciliation/PaymentReconciliationJpaEntity.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/reconciliation/PaymentReconciliationJpaEntity.java
@@ -1,0 +1,64 @@
+package com.trustamarket.orderservice.order.adapter.out.persistence.reconciliation;
+
+import com.trustamarket.common.domain.BaseUserEntity;
+import com.trustamarket.orderservice.order.domain.model.ReconciliationStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+// p_payment_reconciliation 테이블 매핑.
+// 도메인 PaymentReconciliation 과 1:1. Mapper 가 양방향 변환.
+// BaseUserEntity 상속 — created_at/updated_at + created_by/updated_by + deleted_at/deleted_by 자동.
+// 시스템 (스케줄러) 처리라 by 는 AuditorAware 가 system UUID 또는 null 로 채움.
+@Entity
+@Table(name = "p_payment_reconciliation")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentReconciliationJpaEntity extends BaseUserEntity {
+
+    @Id
+    @Column(name = "id", columnDefinition = "uuid", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "order_id", columnDefinition = "uuid", nullable = false, updatable = false, unique = true)
+    private UUID orderId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private ReconciliationStatus status;
+
+    @Column(name = "retry_count", nullable = false)
+    private int retryCount;
+
+    @Column(name = "next_retry_at", nullable = false)
+    private Instant nextRetryAt;
+
+    @Column(name = "last_attempt_at")
+    private Instant lastAttemptAt;
+
+    @Column(name = "last_error", columnDefinition = "text")
+    private String lastError;
+
+    @Builder
+    private PaymentReconciliationJpaEntity(UUID id, UUID orderId, ReconciliationStatus status,
+                                           int retryCount, Instant nextRetryAt,
+                                           Instant lastAttemptAt, String lastError) {
+        this.id = id;
+        this.orderId = orderId;
+        this.status = status;
+        this.retryCount = retryCount;
+        this.nextRetryAt = nextRetryAt;
+        this.lastAttemptAt = lastAttemptAt;
+        this.lastError = lastError;
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/reconciliation/PaymentReconciliationJpaRepository.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/reconciliation/PaymentReconciliationJpaRepository.java
@@ -1,0 +1,19 @@
+package com.trustamarket.orderservice.order.adapter.out.persistence.reconciliation;
+
+import com.trustamarket.orderservice.order.domain.model.ReconciliationStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+// Spring Data JPA — package-private 으로 외부 노출 X. Adapter 가 단일 진입점.
+interface PaymentReconciliationJpaRepository extends JpaRepository<PaymentReconciliationJpaEntity, UUID> {
+
+    // polling 쿼리 — (status, next_retry_at) 인덱스 활용.
+    List<PaymentReconciliationJpaEntity> findByStatusAndNextRetryAtLessThanEqual(
+            ReconciliationStatus status, Instant now, Pageable pageable);
+
+    boolean existsByOrderId(UUID orderId);
+}

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/reconciliation/PaymentReconciliationJpaRepositoryAdapter.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/reconciliation/PaymentReconciliationJpaRepositoryAdapter.java
@@ -4,12 +4,14 @@ import com.trustamarket.orderservice.order.application.port.out.PaymentReconcili
 import com.trustamarket.orderservice.order.domain.model.PaymentReconciliation;
 import com.trustamarket.orderservice.order.domain.model.ReconciliationStatus;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.core.NestedExceptionUtils;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
+import java.sql.SQLException;
 import java.time.Instant;
 import java.util.List;
 
@@ -42,7 +44,22 @@ public class PaymentReconciliationJpaRepositoryAdapter implements PaymentReconci
         }
     }
 
+    // unique violation 식별 — message substring 보다 구조화된 cause 검사가 우선.
+    //   1) Hibernate 의 ConstraintViolationException.constraintName — ORM 이 파싱해서 채워줌
+    //   2) JDBC SQLException.SQLState — "23505" 는 PostgreSQL 표준 unique_violation 코드.
+    //      (DB 가 직접 알려주는 값이라 메시지 파싱보다 드라이버/버전에 안전)
+    //      SQLState 만으로는 어떤 unique 인지 모르므로 message 로 한 번 더 확인.
+    //   3) fallback — message substring (1·2 가 모두 실패할 경우 대비)
     private boolean isOrderIdUniqueViolation(DataIntegrityViolationException e) {
+        for (Throwable cause = e; cause != null; cause = cause.getCause()) {
+            if (cause instanceof ConstraintViolationException cve) {
+                return ORDER_ID_UNIQUE_CONSTRAINT.equals(cve.getConstraintName());
+            }
+            if (cause instanceof SQLException sql && "23505".equals(sql.getSQLState())) {
+                String msg = sql.getMessage();
+                return msg != null && msg.contains(ORDER_ID_UNIQUE_CONSTRAINT);
+            }
+        }
         Throwable root = NestedExceptionUtils.getMostSpecificCause(e);
         String message = root != null ? root.getMessage() : null;
         return message != null && message.contains(ORDER_ID_UNIQUE_CONSTRAINT);

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/reconciliation/PaymentReconciliationJpaRepositoryAdapter.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/reconciliation/PaymentReconciliationJpaRepositoryAdapter.java
@@ -4,6 +4,7 @@ import com.trustamarket.orderservice.order.application.port.out.PaymentReconcili
 import com.trustamarket.orderservice.order.domain.model.PaymentReconciliation;
 import com.trustamarket.orderservice.order.domain.model.ReconciliationStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.NestedExceptionUtils;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -20,6 +21,8 @@ public class PaymentReconciliationJpaRepositoryAdapter implements PaymentReconci
     private final PaymentReconciliationJpaRepository jpaRepository;
     private final PaymentReconciliationMapper mapper;
 
+    private static final String ORDER_ID_UNIQUE_CONSTRAINT = "uq_p_payment_reconciliation_order_id";
+
     // saga catch 안에서 호출. existsByOrderId 로 중복 INSERT 회피 + UNIQUE(order_id) 가 동시성 안전망.
     // TOCTOU race (exists check 통과 후 다른 트랜잭션이 먼저 INSERT) 시 DataIntegrityViolationException 발생 →
     // 멱등 skip (어차피 같은 orderId 의 PENDING row 가 이미 존재).
@@ -31,8 +34,18 @@ public class PaymentReconciliationJpaRepositoryAdapter implements PaymentReconci
         try {
             jpaRepository.save(mapper.toEntity(reconciliation));
         } catch (DataIntegrityViolationException e) {
-            // UNIQUE(order_id) 가 잡은 동시 실패 race — 다른 트랜잭션이 이미 등록했으므로 멱등 skip.
+            // UNIQUE(order_id) 가 잡은 동시 실패 race 만 멱등 skip.
+            // 그 외 제약 위반은 실제 장애로 보고 호출자에게 전파.
+            if (!isOrderIdUniqueViolation(e)) {
+                throw e;
+            }
         }
+    }
+
+    private boolean isOrderIdUniqueViolation(DataIntegrityViolationException e) {
+        Throwable root = NestedExceptionUtils.getMostSpecificCause(e);
+        String message = root != null ? root.getMessage() : null;
+        return message != null && message.contains(ORDER_ID_UNIQUE_CONSTRAINT);
     }
 
     // 결정적 정렬 — nextRetryAt 오름차순으로 가장 오래 대기한 row 부터 처리.

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/reconciliation/PaymentReconciliationJpaRepositoryAdapter.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/reconciliation/PaymentReconciliationJpaRepositoryAdapter.java
@@ -4,7 +4,9 @@ import com.trustamarket.orderservice.order.application.port.out.PaymentReconcili
 import com.trustamarket.orderservice.order.domain.model.PaymentReconciliation;
 import com.trustamarket.orderservice.order.domain.model.ReconciliationStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
@@ -18,20 +20,28 @@ public class PaymentReconciliationJpaRepositoryAdapter implements PaymentReconci
     private final PaymentReconciliationJpaRepository jpaRepository;
     private final PaymentReconciliationMapper mapper;
 
-    // saga catch 안에서 호출. existsByOrderId 로 중복 INSERT 회피.
-    // 동시 실패 race 가 발생해도 UNIQUE (order_id) 제약이 안전망.
+    // saga catch 안에서 호출. existsByOrderId 로 중복 INSERT 회피 + UNIQUE(order_id) 가 동시성 안전망.
+    // TOCTOU race (exists check 통과 후 다른 트랜잭션이 먼저 INSERT) 시 DataIntegrityViolationException 발생 →
+    // 멱등 skip (어차피 같은 orderId 의 PENDING row 가 이미 존재).
     @Override
     public void enqueueIfAbsent(PaymentReconciliation reconciliation) {
         if (jpaRepository.existsByOrderId(reconciliation.getOrderId())) {
             return;
         }
-        jpaRepository.save(mapper.toEntity(reconciliation));
+        try {
+            jpaRepository.save(mapper.toEntity(reconciliation));
+        } catch (DataIntegrityViolationException e) {
+            // UNIQUE(order_id) 가 잡은 동시 실패 race — 다른 트랜잭션이 이미 등록했으므로 멱등 skip.
+        }
     }
 
+    // 결정적 정렬 — nextRetryAt 오름차순으로 가장 오래 대기한 row 부터 처리.
+    // 배치 한도 (50) 초과 백로그 시 특정 row 가 계속 뒤로 밀려 starvation 되는 것 방지.
     @Override
     public List<PaymentReconciliation> findRetriable(Instant now, int limit) {
         return jpaRepository.findByStatusAndNextRetryAtLessThanEqual(
-                ReconciliationStatus.PENDING, now, PageRequest.of(0, limit)
+                ReconciliationStatus.PENDING, now,
+                PageRequest.of(0, limit, Sort.by("nextRetryAt").ascending())
         ).stream()
                 .map(mapper::toDomain)
                 .toList();

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/reconciliation/PaymentReconciliationJpaRepositoryAdapter.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/reconciliation/PaymentReconciliationJpaRepositoryAdapter.java
@@ -1,0 +1,46 @@
+package com.trustamarket.orderservice.order.adapter.out.persistence.reconciliation;
+
+import com.trustamarket.orderservice.order.application.port.out.PaymentReconciliationRepository;
+import com.trustamarket.orderservice.order.domain.model.PaymentReconciliation;
+import com.trustamarket.orderservice.order.domain.model.ReconciliationStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+
+// PaymentReconciliationRepository port 의 JPA 구현 — application 진입점.
+@Repository
+@RequiredArgsConstructor
+public class PaymentReconciliationJpaRepositoryAdapter implements PaymentReconciliationRepository {
+
+    private final PaymentReconciliationJpaRepository jpaRepository;
+    private final PaymentReconciliationMapper mapper;
+
+    // saga catch 안에서 호출. existsByOrderId 로 중복 INSERT 회피.
+    // 동시 실패 race 가 발생해도 UNIQUE (order_id) 제약이 안전망.
+    @Override
+    public void enqueueIfAbsent(PaymentReconciliation reconciliation) {
+        if (jpaRepository.existsByOrderId(reconciliation.getOrderId())) {
+            return;
+        }
+        jpaRepository.save(mapper.toEntity(reconciliation));
+    }
+
+    @Override
+    public List<PaymentReconciliation> findRetriable(Instant now, int limit) {
+        return jpaRepository.findByStatusAndNextRetryAtLessThanEqual(
+                ReconciliationStatus.PENDING, now, PageRequest.of(0, limit)
+        ).stream()
+                .map(mapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public PaymentReconciliation save(PaymentReconciliation reconciliation) {
+        PaymentReconciliationJpaEntity entity = mapper.toEntity(reconciliation);
+        PaymentReconciliationJpaEntity saved = jpaRepository.save(entity);
+        return mapper.toDomain(saved);
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/reconciliation/PaymentReconciliationMapper.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/reconciliation/PaymentReconciliationMapper.java
@@ -1,0 +1,35 @@
+package com.trustamarket.orderservice.order.adapter.out.persistence.reconciliation;
+
+import com.trustamarket.orderservice.order.domain.model.PaymentReconciliation;
+import org.springframework.stereotype.Component;
+
+// 도메인 ↔ JPA Entity 양방향 변환.
+// audit 필드 (createdAt/updatedAt/createdBy/updatedBy/deletedAt/deletedBy) 는 BaseUserEntity 가 JPA Auditing 으로 자동 채움.
+// Mapper 는 도메인 식별/상태/재시도 메타만 다룸.
+@Component
+public class PaymentReconciliationMapper {
+
+    public PaymentReconciliationJpaEntity toEntity(PaymentReconciliation domain) {
+        return PaymentReconciliationJpaEntity.builder()
+                .id(domain.getId())
+                .orderId(domain.getOrderId())
+                .status(domain.getStatus())
+                .retryCount(domain.getRetryCount())
+                .nextRetryAt(domain.getNextRetryAt())
+                .lastAttemptAt(domain.getLastAttemptAt())
+                .lastError(domain.getLastError())
+                .build();
+    }
+
+    public PaymentReconciliation toDomain(PaymentReconciliationJpaEntity entity) {
+        return PaymentReconciliation.builder()
+                .id(entity.getId())
+                .orderId(entity.getOrderId())
+                .status(entity.getStatus())
+                .retryCount(entity.getRetryCount())
+                .nextRetryAt(entity.getNextRetryAt())
+                .lastAttemptAt(entity.getLastAttemptAt())
+                .lastError(entity.getLastError())
+                .build();
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/reconciliation/PaymentReconciliationMapper.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/persistence/reconciliation/PaymentReconciliationMapper.java
@@ -18,6 +18,7 @@ public class PaymentReconciliationMapper {
                 .nextRetryAt(domain.getNextRetryAt())
                 .lastAttemptAt(domain.getLastAttemptAt())
                 .lastError(domain.getLastError())
+                .version(domain.getVersion())
                 .build();
     }
 
@@ -30,6 +31,7 @@ public class PaymentReconciliationMapper {
                 .nextRetryAt(entity.getNextRetryAt())
                 .lastAttemptAt(entity.getLastAttemptAt())
                 .lastError(entity.getLastError())
+                .version(entity.getVersion())
                 .build();
     }
 }

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletFeignClient.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletFeignClient.java
@@ -3,9 +3,12 @@ package com.trustamarket.orderservice.order.adapter.out.wallet;
 import com.trustamarket.common.response.CommonResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import java.time.Instant;
 import java.util.UUID;
 
 // wallet-service `/internal/v1/wallets/usages` 호출용 Feign client.
@@ -15,6 +18,11 @@ public interface WalletFeignClient {
 
     @PatchMapping("/internal/v1/wallets/usages")
     ResponseEntity<CommonResponse<UseWalletResponse>> usePoint(@RequestBody UseWalletRequest request);
+
+    // saga 의 catch / reconciliation scheduler 가 호출 — orderId 로 차감 기록 조회.
+    // wallet 측은 DB 만 읽음 (멱등). 차감 기록 있으면 result=DEDUCTED, 없으면 NOT_DEDUCTED.
+    @GetMapping("/internal/v1/wallets/usages/{orderId}")
+    ResponseEntity<CommonResponse<UsageStatusResponse>> getUsage(@PathVariable UUID orderId);
 
     // wallet-service 의 UseWalletRequest 와 동일 필드명/타입.
     record UseWalletRequest(
@@ -27,5 +35,19 @@ public interface WalletFeignClient {
     record UseWalletResponse(
             Long balance,
             Long shortage
+    ) {}
+
+    // wallet 측 GET /usages/{orderId} 응답.
+    // result = "DEDUCTED" | "INSUFFICIENT" | "NOT_FOUND"
+    //   DEDUCTED     : 차감 완료. amount/balance/deductedAt 채움
+    //   INSUFFICIENT : 잔액 부족으로 wallet 이 거절. balance/shortage 채움
+    //   NOT_FOUND    : 요청 자체가 wallet 에 안 닿음. 모두 null
+    record UsageStatusResponse(
+            UUID orderId,
+            String result,
+            Long amount,
+            Long balance,
+            Long shortage,
+            Instant deductedAt
     ) {}
 }

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletFeignClient.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletFeignClient.java
@@ -5,8 +5,8 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -20,9 +20,10 @@ public interface WalletFeignClient {
     ResponseEntity<CommonResponse<UseWalletResponse>> usePoint(@RequestBody UseWalletRequest request);
 
     // saga 의 catch / reconciliation scheduler 가 호출 — orderId 로 차감 기록 조회.
-    // wallet 측은 DB 만 읽음 (멱등). 차감 기록 있으면 result=DEDUCTED, 없으면 NOT_DEDUCTED.
-    @GetMapping("/internal/v1/wallets/usages/{orderId}")
-    ResponseEntity<CommonResponse<UsageStatusResponse>> getUsage(@PathVariable UUID orderId);
+    // wallet 측은 DB 만 읽음 (멱등). 차감 기록 있으면 DEDUCTED, 거절 기록 있으면 INSUFFICIENT, 없으면 NOT_FOUND.
+    // orderId 는 query parameter — 단건 조회지만 wallet 팀과의 컨벤션상 path 대신 query 사용.
+    @GetMapping("/internal/v1/wallets/usages")
+    ResponseEntity<CommonResponse<UsageStatusResponse>> getUsage(@RequestParam("orderId") UUID orderId);
 
     // wallet-service 의 UseWalletRequest 와 동일 필드명/타입.
     record UseWalletRequest(

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletFeignClient.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletFeignClient.java
@@ -29,7 +29,9 @@ public interface WalletFeignClient {
     ResponseEntity<CommonResponse<UsageStatusResponse>> getUsage(@RequestParam("orderId") UUID orderId);
 
     // wallet-service 의 UseWalletRequest 와 동일 필드명/타입.
+    // idempotencyKey: 사용자 멱등 키. wallet 의 uk_idempotency_key 가 같은 키 재요청 시 멱등 응답 보장.
     record UseWalletRequest(
+            UUID idempotencyKey,
             UUID orderId,
             UUID buyerId,
             Long totalAmount

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletFeignClient.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletFeignClient.java
@@ -1,6 +1,8 @@
 package com.trustamarket.orderservice.order.adapter.out.wallet;
 
 import com.trustamarket.common.response.CommonResponse;
+import com.trustamarket.orderservice.order.domain.exception.InvalidIdException;
+import com.trustamarket.orderservice.order.domain.exception.InvalidMoneyException;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -35,7 +37,15 @@ public interface WalletFeignClient {
             UUID orderId,
             UUID buyerId,
             Long totalAmount
-    ) {}
+    ) {
+        public UseWalletRequest {
+            if (idempotencyKey == null) throw new InvalidIdException("idempotencyKey");
+            if (orderId == null) throw new InvalidIdException("orderId");
+            if (buyerId == null) throw new InvalidIdException("buyerId");
+            if (totalAmount == null) throw new InvalidMoneyException("totalAmount");
+            if (totalAmount <= 0) throw new InvalidMoneyException(totalAmount);
+        }
+    }
 
     // wallet-service 의 UseWalletResponse 와 동일 필드명/타입.
     record UseWalletResponse(
@@ -55,5 +65,11 @@ public interface WalletFeignClient {
             Long balance,
             Long shortage,
             Instant deductedAt
-    ) {}
+    ) {
+        public UsageStatusResponse {
+            // 기본 무결성 — 결과별 nullable 규칙은 Adapter 가 enum 변환 후 검증.
+            if (orderId == null) throw new InvalidIdException("orderId");
+            if (result == null || result.isBlank()) throw new InvalidIdException("result");
+        }
+    }
 }

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletFeignClient.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletFeignClient.java
@@ -19,8 +19,11 @@ public interface WalletFeignClient {
     @PatchMapping("/internal/v1/wallets/usages")
     ResponseEntity<CommonResponse<UseWalletResponse>> usePoint(@RequestBody UseWalletRequest request);
 
-    // saga 의 catch / reconciliation scheduler 가 호출 — orderId 로 차감 기록 조회.
-    // wallet 측은 DB 만 읽음 (멱등). 차감 기록 있으면 DEDUCTED, 거절 기록 있으면 INSUFFICIENT, 없으면 NOT_FOUND.
+    // saga 의 catch / reconciliation scheduler 가 호출 — orderId 로 거래 기록 조회.
+    // wallet 측은 DB 만 읽음 (멱등).
+    //   차감 기록 있음 → DEDUCTED
+    //   거절 기록 있음 → INSUFFICIENT (잔액 부족으로 wallet 이 받아 거절)
+    //   기록 없음     → NOT_FOUND (요청 자체가 wallet 에 안 닿음)
     // orderId 는 query parameter — 단건 조회지만 wallet 팀과의 컨벤션상 path 대신 query 사용.
     @GetMapping("/internal/v1/wallets/usages")
     ResponseEntity<CommonResponse<UsageStatusResponse>> getUsage(@RequestParam("orderId") UUID orderId);

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletFeignClient.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletFeignClient.java
@@ -53,7 +53,7 @@ public interface WalletFeignClient {
             Long shortage
     ) {}
 
-    // wallet 측 GET /usages/{orderId} 응답.
+    // wallet 측 GET /internal/v1/wallets/usages?orderId=... 응답.
     // result = "DEDUCTED" | "INSUFFICIENT" | "NOT_FOUND"
     //   DEDUCTED     : 차감 완료. amount/balance/deductedAt 채움
     //   INSUFFICIENT : 잔액 부족으로 wallet 이 거절. balance/shortage 채움

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletPaymentAdapter.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletPaymentAdapter.java
@@ -66,6 +66,12 @@ public class WalletPaymentAdapter implements WalletPaymentPort {
                 log.error("[Wallet] getUsage 빈/비정상 응답 — orderId={}", orderId);
                 throw new WalletCommunicationException();
             }
+            // 응답 orderId 무결성 — 잘못된 응답이 다른 주문에 적용되는 오판정 방지.
+            if (!orderId.equals(data.orderId())) {
+                log.error("[Wallet] getUsage orderId 불일치 — requested={}, response={}",
+                        orderId, data.orderId());
+                throw new WalletCommunicationException();
+            }
             UsageStatus.Result result;
             try {
                 result = UsageStatus.Result.valueOf(data.result());

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletPaymentAdapter.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletPaymentAdapter.java
@@ -51,8 +51,8 @@ public class WalletPaymentAdapter implements WalletPaymentPort {
     }
 
     // saga catch / reconciliation scheduler 에서 호출.
-    // wallet 측 GET /internal/v1/wallets/usages/{orderId}.
-    // 응답 result 가 "DEDUCTED" 또는 "NOT_DEDUCTED" — 그 외 값 / null 은 비정상 응답으로 본다.
+    // wallet 측 GET /internal/v1/wallets/usages?orderId=...
+    // 응답 result 가 "DEDUCTED" / "INSUFFICIENT" / "NOT_FOUND" — 그 외 값 / null 은 비정상 응답으로 본다.
     // 통신 실패는 WalletCommunicationException → 호출자가 UNKNOWN 으로 분기 (DB queue).
     @Override
     public UsageStatus getUsage(UUID orderId) {

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletPaymentAdapter.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletPaymentAdapter.java
@@ -26,6 +26,7 @@ public class WalletPaymentAdapter implements WalletPaymentPort {
         try {
             ResponseEntity<CommonResponse<WalletFeignClient.UseWalletResponse>> response = walletFeignClient.usePoint(
                     new WalletFeignClient.UseWalletRequest(
+                            request.idempotencyKey(),
                             request.orderId(),
                             request.buyerId(),
                             request.totalAmount()

--- a/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletPaymentAdapter.java
+++ b/src/main/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletPaymentAdapter.java
@@ -9,8 +9,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
+import java.util.UUID;
+
 // WalletPaymentPort 실 구현 — Feign 으로 wallet-service 의 /internal/v1/wallets/usages 호출.
-// wallet 응답이 CommonResponse<UseWalletResponse> 로 래핑되어 있어 Adapter 에서 unwrap.
+// wallet 응답이 CommonResponse<...> 로 래핑되어 있어 Adapter 에서 unwrap.
 // 통신 실패(타임아웃/5xx 등)는 WalletCommunicationException 으로 변환 (도메인 의미로 추상화).
 @Slf4j
 @Component
@@ -44,6 +46,45 @@ public class WalletPaymentAdapter implements WalletPaymentPort {
         } catch (FeignException e) {
             log.error("[Wallet] Feign 호출 실패 — orderId={}, status={}",
                     request.orderId(), e.status(), e);
+            throw new WalletCommunicationException(e);
+        }
+    }
+
+    // saga catch / reconciliation scheduler 에서 호출.
+    // wallet 측 GET /internal/v1/wallets/usages/{orderId}.
+    // 응답 result 가 "DEDUCTED" 또는 "NOT_DEDUCTED" — 그 외 값 / null 은 비정상 응답으로 본다.
+    // 통신 실패는 WalletCommunicationException → 호출자가 UNKNOWN 으로 분기 (DB queue).
+    @Override
+    public UsageStatus getUsage(UUID orderId) {
+        try {
+            ResponseEntity<CommonResponse<WalletFeignClient.UsageStatusResponse>> response =
+                    walletFeignClient.getUsage(orderId);
+            CommonResponse<WalletFeignClient.UsageStatusResponse> body =
+                    response != null ? response.getBody() : null;
+            WalletFeignClient.UsageStatusResponse data = body != null ? body.data() : null;
+            if (data == null || data.result() == null) {
+                log.error("[Wallet] getUsage 빈/비정상 응답 — orderId={}", orderId);
+                throw new WalletCommunicationException();
+            }
+            UsageStatus.Result result;
+            try {
+                result = UsageStatus.Result.valueOf(data.result());
+            } catch (IllegalArgumentException ex) {
+                log.error("[Wallet] getUsage 알 수 없는 result — orderId={}, result={}",
+                        orderId, data.result());
+                throw new WalletCommunicationException(ex);
+            }
+            return new UsageStatus(
+                    data.orderId(),
+                    result,
+                    data.amount(),
+                    data.balance(),
+                    data.shortage(),
+                    data.deductedAt()
+            );
+        } catch (FeignException e) {
+            log.error("[Wallet] getUsage Feign 호출 실패 — orderId={}, status={}",
+                    orderId, e.status(), e);
             throw new WalletCommunicationException(e);
         }
     }

--- a/src/main/java/com/trustamarket/orderservice/order/application/port/in/RequestPaymentUseCase.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/port/in/RequestPaymentUseCase.java
@@ -13,13 +13,18 @@ public interface RequestPaymentUseCase {
     record RequestPaymentCommand(
             UUID orderId,
             UUID buyerId,             // 권한 검증용 (== order.buyer.id)
-            String idempotencyKey     // Idempotency-Key 헤더 — 중복 결제 차단
+            String idempotencyKey     // Idempotency-Key 헤더 — 중복 결제 차단. wallet 으로도 그대로 전달되므로 UUID 형식 강제.
     ) {
         public RequestPaymentCommand {
             if (orderId == null) throw new InvalidIdException("orderId");
             if (buyerId == null) throw new InvalidIdException("buyerId");
             // 진입점 (controller 외 테스트/배치 등) 무관하게 record 가 직접 보장.
             if (idempotencyKey == null || idempotencyKey.isBlank()) {
+                throw new InvalidIdException("idempotencyKey");
+            }
+            try {
+                UUID.fromString(idempotencyKey);
+            } catch (IllegalArgumentException ignored) {
                 throw new InvalidIdException("idempotencyKey");
             }
         }

--- a/src/main/java/com/trustamarket/orderservice/order/application/port/out/PaymentReconciliationRepository.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/port/out/PaymentReconciliationRepository.java
@@ -1,0 +1,21 @@
+package com.trustamarket.orderservice.order.application.port.out;
+
+import com.trustamarket.orderservice.order.domain.model.PaymentReconciliation;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+// PaymentReconciliation 영속화 port (out).
+public interface PaymentReconciliationRepository {
+
+    // 새 PENDING row 등록. 같은 orderId 가 이미 있으면 INSERT 안 함 (조용히 skip).
+    // saga catch 안에서 호출 — 동시 실패 케이스에서 중복 등록 방지.
+    void enqueueIfAbsent(PaymentReconciliation reconciliation);
+
+    // 폴링 — 한 번에 가져올 row 수 제한.
+    List<PaymentReconciliation> findRetriable(Instant now, int limit);
+
+    // 도메인 상태 변경 후 저장.
+    PaymentReconciliation save(PaymentReconciliation reconciliation);
+}

--- a/src/main/java/com/trustamarket/orderservice/order/application/port/out/ReconciliationAlertPort.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/port/out/ReconciliationAlertPort.java
@@ -1,0 +1,11 @@
+package com.trustamarket.orderservice.order.application.port.out;
+
+import java.util.UUID;
+
+// GIVEN_UP 상태 도달 시 운영자 알림 (Discord webhook 등) 발송 port.
+// Adapter 가 notification-service / Discord 등 실제 채널로 전달.
+// best-effort — 실패해도 reconciliation 본 흐름엔 영향 X.
+public interface ReconciliationAlertPort {
+
+    void notifyGivenUp(UUID orderId, int retryCount, String lastError);
+}

--- a/src/main/java/com/trustamarket/orderservice/order/application/port/out/WalletPaymentPort.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/port/out/WalletPaymentPort.java
@@ -3,16 +3,22 @@ package com.trustamarket.orderservice.order.application.port.out;
 import com.trustamarket.orderservice.order.domain.exception.InvalidIdException;
 import com.trustamarket.orderservice.order.domain.exception.InvalidMoneyException;
 
+import java.time.Instant;
 import java.util.UUID;
 
 // 주문 → 포인트 사용 (Wallet 동기 호출) port — Wallet 팀과 합의된 시그니처
-// HTTP 응답은 CommonResponse<DeductPointResponse>로 래핑 — Feign 어댑터(후속 PR)에서 unwrap 후 반환
+// HTTP 응답은 CommonResponse<...>로 래핑 — Feign 어댑터(후속 PR)에서 unwrap 후 반환
 // application 레이어는 CommonResponse 모름 (HTTP 디테일 격리)
 public interface WalletPaymentPort {
 
     // 주문 결제 시점에 포인트 차감 요청
     DeductPointResponse deduct(DeductPointRequest request);
     // 취소 흐름은 sync 호출이 아닌 Kafka (order.cancellation.requested) 로 진행 — 본 port 와 무관.
+
+    // saga 의 wallet 차감 호출이 timeout / 5xx 등 비정상 응답을 받았을 때 결과 확인용.
+    // wallet 측은 DB 만 조회 (멱등). 차감 기록 있으면 DEDUCTED, 없으면 NOT_DEDUCTED.
+    // wallet 자체가 응답 못 하는 케이스 (또 timeout / 5xx) 는 Adapter 가 RuntimeException → 호출자가 UNKNOWN 처리.
+    UsageStatus getUsage(UUID orderId);
 
     // 주문 -> 포인트 사용 요청 DTO
     // 금액은 룰 [3]에 따라 long(원시형) 사용. compact constructor로 입력 검증
@@ -36,6 +42,29 @@ public interface WalletPaymentPort {
     ) {
         public boolean isSuccess() {
             return shortage == null || shortage == 0;
+        }
+    }
+
+    // getUsage 응답 — wallet 측 DB 조회 결과 그대로 반영.
+    //   DEDUCTED     : 차감 기록 있음. amount / balance / deductedAt 채워짐
+    //   INSUFFICIENT : 거절 기록 있음 (wallet 이 받아 잔액 부족으로 거절). balance / shortage 채워짐
+    //   NOT_FOUND    : 어떤 기록도 없음 (요청이 wallet 에 안 닿음). 다 null
+    record UsageStatus(
+            UUID orderId,
+            Result result,
+            Long amount,
+            Long balance,
+            Long shortage,
+            Instant deductedAt
+    ) {
+        public boolean isDeducted() {
+            return result == Result.DEDUCTED;
+        }
+
+        public enum Result {
+            DEDUCTED,
+            INSUFFICIENT,
+            NOT_FOUND
         }
     }
 }

--- a/src/main/java/com/trustamarket/orderservice/order/application/port/out/WalletPaymentPort.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/port/out/WalletPaymentPort.java
@@ -16,7 +16,10 @@ public interface WalletPaymentPort {
     // 취소 흐름은 sync 호출이 아닌 Kafka (order.cancellation.requested) 로 진행 — 본 port 와 무관.
 
     // saga 의 wallet 차감 호출이 timeout / 5xx 등 비정상 응답을 받았을 때 결과 확인용.
-    // wallet 측은 DB 만 조회 (멱등). 차감 기록 있으면 DEDUCTED, 없으면 NOT_DEDUCTED.
+    // wallet 측은 DB 만 조회 (멱등).
+    //   차감 기록 있음 → DEDUCTED
+    //   거절 기록 있음 → INSUFFICIENT (잔액 부족 거절)
+    //   기록 없음     → NOT_FOUND
     // wallet 자체가 응답 못 하는 케이스 (또 timeout / 5xx) 는 Adapter 가 RuntimeException → 호출자가 UNKNOWN 처리.
     UsageStatus getUsage(UUID orderId);
 
@@ -57,6 +60,13 @@ public interface WalletPaymentPort {
             Long shortage,
             Instant deductedAt
     ) {
+        // 필수 필드 (orderId / result) 만 검증 — 그 외는 result 에 따라 nullable.
+        // 호출부 (saga catch / Processor) 가 switch(usage.result()) 로 분기하므로 null 차단 필수.
+        public UsageStatus {
+            if (orderId == null) throw new InvalidIdException("orderId");
+            if (result == null) throw new InvalidIdException("result");
+        }
+
         public boolean isDeducted() {
             return result == Result.DEDUCTED;
         }

--- a/src/main/java/com/trustamarket/orderservice/order/application/port/out/WalletPaymentPort.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/port/out/WalletPaymentPort.java
@@ -25,12 +25,16 @@ public interface WalletPaymentPort {
 
     // 주문 -> 포인트 사용 요청 DTO
     // 금액은 룰 [3]에 따라 long(원시형) 사용. compact constructor로 입력 검증
+    // idempotencyKey: 사용자 Idempotency-Key (= inbox.tryRecordIdempotencyKey 와 동일 값).
+    //                  wallet 이 같은 키 재요청 시 멱등 응답 보장 — 우리 inbox 가 1차 차단, wallet 멱등이 안전망.
     record DeductPointRequest(
+            UUID idempotencyKey,
             UUID orderId,
             UUID buyerId,
             long totalAmount     // 차감 요청 금액 = product price + shipping fee, 양수
     ) {
         public DeductPointRequest {
+            if (idempotencyKey == null) throw new InvalidIdException("idempotencyKey");
             if (orderId == null) throw new InvalidIdException("orderId");
             if (buyerId == null) throw new InvalidIdException("buyerId");
             if (totalAmount <= 0) throw new InvalidMoneyException(totalAmount);

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentService.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentService.java
@@ -169,13 +169,11 @@ public class RequestPaymentService implements RequestPaymentUseCase {
     // 이유: wallet 은 이미 차감됐는데 (deduct 성공 또는 getUsage=DEDUCTED) tx2 가 깨지면
     // order 가 PAYMENT_PENDING + outbox 없음 → 영구 stuck. 큐에 넣어 scheduler 가 정리하게.
     //
-    // catch 분리: 도메인 결정적 예외 (OrderException) 는 retry 무의미 → 그대로 전파.
-    // 일시적 인프라 / 알 수 없는 예외 (DataAccessException 등) 만 큐로 위임.
+    // 도메인 결정적 예외 (OrderException) 도 같이 큐로 위임 — wallet 차감 후 throw 하면 영구 stuck.
+    // retry 가 무의미한 케이스는 reconciliation processor 의 비재시도 분류 (이슈 #59) 가 즉시 GIVEN_UP 처리.
     private void finalizePaidOrEnqueue(OrderId orderId) {
         try {
             markPaidAndPublish(orderId);
-        } catch (com.trustamarket.orderservice.order.domain.exception.OrderException e) {
-            throw e;
         } catch (RuntimeException e) {
             log.error("[saga] markPaidAndPublish 실패 — reconciliation 큐로 위임. orderId={}", orderId, e);
             reconciliationRepository.enqueueIfAbsent(
@@ -210,10 +208,10 @@ public class RequestPaymentService implements RequestPaymentUseCase {
     // SAGA 상태 복귀 (보상 트랜잭션 아님) — PAYMENT_PENDING → REQUESTED.
     // 1-step saga 라 wallet 에 되돌릴 외부 변경 없음. order 상태만 복귀.
     //
-    // catch 분리: 도메인 결정적 예외 (OrderException) 는 그대로 전파 — retry 무의미.
-    // 일시적 인프라 / 알 수 없는 예외만 큐로 위임 + PaymentVerificationPendingException 던져 사용자에 202 응답.
-    // 후자의 경우 호출자가 던지려던 InsufficientPointBalanceException / WalletCommunicationException 등은 도달 X —
+    // 모든 실패는 reconciliation 큐로 위임 + PaymentVerificationPendingException 던져 사용자에 202 응답.
+    // 호출자가 던지려던 InsufficientPointBalanceException / WalletCommunicationException 등은 도달 X —
     // rollback 실패면 order 가 PAYMENT_PENDING 으로 stuck 이라 "처리 중" 응답이 더 정확.
+    // 도메인 결정적 예외 (OrderException) 도 큐로 위임 — finalizePaidOrEnqueue 와 동일 패턴.
     private void rollbackToRequested(OrderId orderId) {
         try {
             txTemplate.execute(status -> {
@@ -224,8 +222,6 @@ public class RequestPaymentService implements RequestPaymentUseCase {
                 orderRepository.save(order);
                 return null;
             });
-        } catch (com.trustamarket.orderservice.order.domain.exception.OrderException e) {
-            throw e;
         } catch (RuntimeException e) {
             log.error("[saga] rollbackToRequested 실패 — reconciliation 큐로 위임. orderId={}", orderId, e);
             reconciliationRepository.enqueueIfAbsent(

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentService.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentService.java
@@ -23,6 +23,7 @@ import com.trustamarket.orderservice.order.domain.model.OrderId;
 import com.trustamarket.orderservice.order.domain.model.OrderStatus;
 import com.trustamarket.orderservice.order.domain.model.PaymentReconciliation;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -48,6 +49,7 @@ import java.time.Instant;
 // NOT_FOUND / INSUFFICIENT 는 wallet 에 외부 변경이 없으므로 order 상태만 REQUESTED 로 복귀.
 //
 // Idempotency-Key 검증: RequestPaymentCommand compact constructor 가 NotBlank 보장.
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RequestPaymentService implements RequestPaymentUseCase {
@@ -181,16 +183,22 @@ public class RequestPaymentService implements RequestPaymentUseCase {
 
     // SAGA 상태 복귀 (보상 트랜잭션 아님) — PAYMENT_PENDING → REQUESTED.
     // 1-step saga 라 wallet 에 되돌릴 외부 변경 없음. order 상태만 복귀.
-    // 본 트랜잭션이 실패하면 reconciliation enqueue 없이 PAYMENT_PENDING 으로 stuck — 현재 자동 복구 경로 없음.
-    // TODO: rollback 실패 시 enqueueIfAbsent 안전망 추가 (후속 PR).
+    // 본 트랜잭션이 깨지면 reconciliation 큐로 위임 — scheduler 가 백오프 후 getUsage 재시도하면서 결국 정리.
     private void rollbackToRequested(OrderId orderId) {
-        txTemplate.execute(status -> {
-            Order order = orderRepository.findByIdOrThrow(orderId);
-            OrderStatus pre = order.getStatus();
-            order.rollbackPaymentRequest();
-            historyRecorder.record(order.getId(), pre, order.getStatus(), null);
-            orderRepository.save(order);
-            return null;
-        });
+        try {
+            txTemplate.execute(status -> {
+                Order order = orderRepository.findByIdOrThrow(orderId);
+                OrderStatus pre = order.getStatus();
+                order.rollbackPaymentRequest();
+                historyRecorder.record(order.getId(), pre, order.getStatus(), null);
+                orderRepository.save(order);
+                return null;
+            });
+        } catch (RuntimeException e) {
+            log.error("[saga] rollbackToRequested 실패 — reconciliation 큐로 위임. orderId={}", orderId, e);
+            reconciliationRepository.enqueueIfAbsent(
+                    PaymentReconciliation.enqueue(orderId.value(), Instant.now())
+            );
+        }
     }
 }

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentService.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentService.java
@@ -119,7 +119,7 @@ public class RequestPaymentService implements RequestPaymentUseCase {
         }
 
         // ── [tx2] 성공: PAID + outbox ──
-        markPaidAndPublish(orderId);
+        finalizePaidOrEnqueue(orderId);
     }
 
     // saga catch 안에서 wallet 결과를 재확인하는 분기.
@@ -140,7 +140,7 @@ public class RequestPaymentService implements RequestPaymentUseCase {
         }
 
         switch (usage.result()) {
-            case DEDUCTED -> markPaidAndPublish(orderId);
+            case DEDUCTED -> finalizePaidOrEnqueue(orderId);
             case INSUFFICIENT -> {
                 rollbackToRequested(orderId);
                 throw new InsufficientPointBalanceException(
@@ -156,6 +156,21 @@ public class RequestPaymentService implements RequestPaymentUseCase {
             // 새 Result 값 추가 시 컴파일 통과돼도 default 가 즉시 실패시켜 회귀를 조기에 드러낸다.
             default -> throw new IllegalStateException(
                     "Unexpected wallet usage result: " + usage.result());
+        }
+    }
+
+    // tx2 wrapper — markPaidAndPublish 실패 시 reconciliation 큐로 위임 후 PaymentVerificationPendingException.
+    // 이유: wallet 은 이미 차감됐는데 (deduct 성공 또는 getUsage=DEDUCTED) tx2 가 깨지면
+    // order 가 PAYMENT_PENDING + outbox 없음 → 영구 stuck. 큐에 넣어 scheduler 가 정리하게.
+    private void finalizePaidOrEnqueue(OrderId orderId) {
+        try {
+            markPaidAndPublish(orderId);
+        } catch (RuntimeException e) {
+            log.error("[saga] markPaidAndPublish 실패 — reconciliation 큐로 위임. orderId={}", orderId, e);
+            reconciliationRepository.enqueueIfAbsent(
+                    PaymentReconciliation.enqueue(orderId.value(), Instant.now())
+            );
+            throw new PaymentVerificationPendingException(orderId.value(), e);
         }
     }
 
@@ -183,7 +198,9 @@ public class RequestPaymentService implements RequestPaymentUseCase {
 
     // SAGA 상태 복귀 (보상 트랜잭션 아님) — PAYMENT_PENDING → REQUESTED.
     // 1-step saga 라 wallet 에 되돌릴 외부 변경 없음. order 상태만 복귀.
-    // 본 트랜잭션이 깨지면 reconciliation 큐로 위임 — scheduler 가 백오프 후 getUsage 재시도하면서 결국 정리.
+    // 본 트랜잭션이 깨지면 reconciliation 큐로 위임 + PaymentVerificationPendingException 던져 사용자에 202 응답.
+    // 호출자가 던지려던 InsufficientPointBalanceException / WalletCommunicationException 등은 도달 X —
+    // rollback 실패면 order 가 PAYMENT_PENDING 으로 stuck 이라 "처리 중" 응답이 더 정확.
     private void rollbackToRequested(OrderId orderId) {
         try {
             txTemplate.execute(status -> {
@@ -199,6 +216,7 @@ public class RequestPaymentService implements RequestPaymentUseCase {
             reconciliationRepository.enqueueIfAbsent(
                     PaymentReconciliation.enqueue(orderId.value(), Instant.now())
             );
+            throw new PaymentVerificationPendingException(orderId.value(), e);
         }
     }
 }

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentService.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentService.java
@@ -8,29 +8,44 @@ import com.trustamarket.orderservice.order.application.port.in.RequestPaymentUse
 import com.trustamarket.orderservice.order.application.port.out.InboxRepository;
 import com.trustamarket.orderservice.order.application.port.out.InboxRepository.InboxPurposeKey;
 import com.trustamarket.orderservice.order.application.port.out.OrderRepository;
+import com.trustamarket.orderservice.order.application.port.out.PaymentReconciliationRepository;
 import com.trustamarket.orderservice.order.application.port.out.WalletPaymentPort;
 import com.trustamarket.orderservice.order.application.port.out.WalletPaymentPort.DeductPointRequest;
 import com.trustamarket.orderservice.order.application.port.out.WalletPaymentPort.DeductPointResponse;
+import com.trustamarket.orderservice.order.application.port.out.WalletPaymentPort.UsageStatus;
 import com.trustamarket.orderservice.order.application.service.support.OrderAccessGuard;
 import com.trustamarket.orderservice.order.application.service.support.OrderHistoryRecorder;
 import com.trustamarket.orderservice.order.domain.exception.InsufficientPointBalanceException;
+import com.trustamarket.orderservice.order.domain.exception.PaymentVerificationPendingException;
 import com.trustamarket.orderservice.order.domain.exception.WalletCommunicationException;
 import com.trustamarket.orderservice.order.domain.model.Order;
 import com.trustamarket.orderservice.order.domain.model.OrderId;
 import com.trustamarket.orderservice.order.domain.model.OrderStatus;
+import com.trustamarket.orderservice.order.domain.model.PaymentReconciliation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import java.time.Instant;
+
 // REQUESTED → PAYMENT_PENDING → (Wallet sync) → PAID
 // Saga 분리: wallet feign call 이 tx 밖이라 connection hold X.
-//   [tx1] order load + requestPayment() — PAYMENT_PENDING commit (짧음, ~50ms)
-//   [no tx] walletPaymentPort.deduct() — Feign 호출 (응답 timeout 5초까지 wait, connection 없음)
-//   [tx2] 성공: markPaid() + outbox publish (commit)
-//          실패: rollbackPaymentRequest() — PAYMENT_PENDING → REQUESTED (보상)
+//   [tx1]    order load + requestPayment() — PAYMENT_PENDING commit (짧음, ~50ms)
+//   [no tx]  walletPaymentPort.deduct() — Feign 호출 (응답 timeout 5초까지 wait, connection 없음)
+//   [tx2]    성공: markPaid() + outbox publish (commit)
+//            실패: rollbackToRequested() — PAYMENT_PENDING → REQUESTED (상태 복귀)
 //
-// 보상 실패 시 (tx2 의 rollback 자체가 fail) order 가 PAYMENT_PENDING 으로 stuck.
-// → 별도 reconciliation job 필요 (현재 미구현, follow-up).
+// 비정상 응답 (timeout / 5xx) 처리:
+//   walletPaymentPort.getUsage(orderId) 로 결과 재확인
+//     DEDUCTED     → markPaid()                                    (wallet 은 차감했고 응답만 손실)
+//     INSUFFICIENT → rollbackToRequested + InsufficientPointBalanceException
+//     NOT_FOUND    → rollbackToRequested + WalletCommunicationException
+//   getUsage 자체도 실패 → reconciliation 큐 등록 + PaymentVerificationPendingException
+//                          → 사용자에게 "결제 처리 중" 응답
+//                          → @Scheduled 가 백오프 (30s/60s/120s) 로 재시도
+//
+// 1-step saga 이므로 토스 환전 사례의 "출금 취소" 같은 보상 트랜잭션 없음.
+// NOT_FOUND / INSUFFICIENT 는 wallet 에 외부 변경이 없으므로 order 상태만 REQUESTED 로 복귀.
 //
 // Idempotency-Key 검증: RequestPaymentCommand compact constructor 가 NotBlank 보장.
 @Service
@@ -43,6 +58,7 @@ public class RequestPaymentService implements RequestPaymentUseCase {
     private final OrderHistoryRecorder historyRecorder;
     private final WalletPaymentPort walletPaymentPort;
     private final InboxRepository inboxRepository;
+    private final PaymentReconciliationRepository reconciliationRepository;
     private final TransactionTemplate txTemplate;
 
     @Override
@@ -74,19 +90,25 @@ public class RequestPaymentService implements RequestPaymentUseCase {
                     new DeductPointRequest(cmd.orderId(), cmd.buyerId(), totalAmount)
             );
             if (res == null) {
-                compensateToRequested(orderId);
                 throw new WalletCommunicationException();
             }
+        } catch (WalletCommunicationException e) {
+            // 비정상 응답 (timeout / 5xx) — Adapter 가 모두 이 예외로 통일. getUsage 재확인 후 분기.
+            handleUnknownResult(orderId, totalAmount, e);
+            return;
         } catch (com.trustamarket.orderservice.order.domain.exception.OrderException e) {
-            compensateToRequested(orderId);
+            // 기타 도메인 예외 (검증 실패 등) — 결과 확인 무의미. 즉시 상태 복귀.
+            rollbackToRequested(orderId);
             throw e;
         } catch (RuntimeException e) {
-            compensateToRequested(orderId);
-            throw new WalletCommunicationException(e);
+            // 예상 못 한 런타임 — 안전망. getUsage 재확인 후 분기.
+            handleUnknownResult(orderId, totalAmount, e);
+            return;
         }
 
         if (!res.isSuccess()) {
-            compensateToRequested(orderId);
+            // 정상 응답이지만 잔액 부족 — 즉시 상태 복귀.
+            rollbackToRequested(orderId);
             throw new InsufficientPointBalanceException(
                     totalAmount,
                     res.balance() == null ? 0 : res.balance(),
@@ -94,7 +116,46 @@ public class RequestPaymentService implements RequestPaymentUseCase {
             );
         }
 
-        // ── [tx2] 짧은 DB UPDATE: PAYMENT_PENDING → PAID + outbox publish ──
+        // ── [tx2] 성공: PAID + outbox ──
+        markPaidAndPublish(orderId);
+    }
+
+    // saga catch 안에서 wallet 결과를 재확인하는 분기.
+    // - DEDUCTED     → markPaid + outbox (성공으로 처리)
+    // - INSUFFICIENT → rollbackToRequested + InsufficientPointBalanceException (잔액 부족)
+    // - NOT_FOUND    → rollbackToRequested + WalletCommunicationException (요청이 wallet 에 안 닿음)
+    // - getUsage 자체 실패 → reconciliation 큐 등록 + PaymentVerificationPendingException (재시도 위임)
+    private void handleUnknownResult(OrderId orderId, long totalAmount, RuntimeException original) {
+        UsageStatus usage;
+        try {
+            usage = walletPaymentPort.getUsage(orderId.value());
+        } catch (RuntimeException verifyEx) {
+            // 결과 확인도 실패 — DB queue 에 등록하고 사용자에게 "결제 처리 중" 응답.
+            reconciliationRepository.enqueueIfAbsent(
+                    PaymentReconciliation.enqueue(orderId.value(), Instant.now())
+            );
+            throw new PaymentVerificationPendingException(orderId.value(), verifyEx);
+        }
+
+        switch (usage.result()) {
+            case DEDUCTED -> markPaidAndPublish(orderId);
+            case INSUFFICIENT -> {
+                rollbackToRequested(orderId);
+                throw new InsufficientPointBalanceException(
+                        totalAmount,
+                        usage.balance() == null ? 0 : usage.balance(),
+                        usage.shortage()
+                );
+            }
+            case NOT_FOUND -> {
+                rollbackToRequested(orderId);
+                throw new WalletCommunicationException(original);
+            }
+        }
+    }
+
+    // tx2 — PAYMENT_PENDING → PAID + outbox publish.
+    private void markPaidAndPublish(OrderId orderId) {
         txTemplate.execute(status -> {
             Order order = orderRepository.findByIdOrThrow(orderId);
             OrderStatus prePaid = order.getStatus();
@@ -115,9 +176,10 @@ public class RequestPaymentService implements RequestPaymentUseCase {
         });
     }
 
-    // Saga 보상 — PAYMENT_PENDING → REQUESTED 복귀.
-    // 본 트랜잭션은 항상 commit 시도. 실패 시 order 가 PAYMENT_PENDING 으로 stuck → reconciliation job 으로 복구 (follow-up).
-    private void compensateToRequested(OrderId orderId) {
+    // SAGA 상태 복귀 (보상 트랜잭션 아님) — PAYMENT_PENDING → REQUESTED.
+    // 1-step saga 라 wallet 에 되돌릴 외부 변경 없음. order 상태만 복귀.
+    // 본 트랜잭션 실패 시 PAYMENT_PENDING 으로 stuck → reconciliation 스케줄러가 백오프 후 처리.
+    private void rollbackToRequested(OrderId orderId) {
         txTemplate.execute(status -> {
             Order order = orderRepository.findByIdOrThrow(orderId);
             OrderStatus pre = order.getStatus();

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentService.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentService.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.Instant;
+import java.util.UUID;
 
 // REQUESTED → PAYMENT_PENDING → (Wallet sync) → PAID
 // Saga 분리: wallet feign call 이 tx 밖이라 connection hold X.
@@ -89,7 +90,12 @@ public class RequestPaymentService implements RequestPaymentUseCase {
         DeductPointResponse res;
         try {
             res = walletPaymentPort.deduct(
-                    new DeductPointRequest(cmd.orderId(), cmd.buyerId(), totalAmount)
+                    new DeductPointRequest(
+                            UUID.fromString(cmd.idempotencyKey()),
+                            cmd.orderId(),
+                            cmd.buyerId(),
+                            totalAmount
+                    )
             );
             if (res == null) {
                 throw new WalletCommunicationException();

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentService.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentService.java
@@ -151,6 +151,9 @@ public class RequestPaymentService implements RequestPaymentUseCase {
                 rollbackToRequested(orderId);
                 throw new WalletCommunicationException(original);
             }
+            // 새 Result 값 추가 시 컴파일 통과돼도 default 가 즉시 실패시켜 회귀를 조기에 드러낸다.
+            default -> throw new IllegalStateException(
+                    "Unexpected wallet usage result: " + usage.result());
         }
     }
 
@@ -178,7 +181,8 @@ public class RequestPaymentService implements RequestPaymentUseCase {
 
     // SAGA 상태 복귀 (보상 트랜잭션 아님) — PAYMENT_PENDING → REQUESTED.
     // 1-step saga 라 wallet 에 되돌릴 외부 변경 없음. order 상태만 복귀.
-    // 본 트랜잭션 실패 시 PAYMENT_PENDING 으로 stuck → reconciliation 스케줄러가 백오프 후 처리.
+    // 본 트랜잭션이 실패하면 reconciliation enqueue 없이 PAYMENT_PENDING 으로 stuck — 현재 자동 복구 경로 없음.
+    // TODO: rollback 실패 시 enqueueIfAbsent 안전망 추가 (후속 PR).
     private void rollbackToRequested(OrderId orderId) {
         txTemplate.execute(status -> {
             Order order = orderRepository.findByIdOrThrow(orderId);

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentService.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentService.java
@@ -162,9 +162,14 @@ public class RequestPaymentService implements RequestPaymentUseCase {
     // tx2 wrapper — markPaidAndPublish 실패 시 reconciliation 큐로 위임 후 PaymentVerificationPendingException.
     // 이유: wallet 은 이미 차감됐는데 (deduct 성공 또는 getUsage=DEDUCTED) tx2 가 깨지면
     // order 가 PAYMENT_PENDING + outbox 없음 → 영구 stuck. 큐에 넣어 scheduler 가 정리하게.
+    //
+    // catch 분리: 도메인 결정적 예외 (OrderException) 는 retry 무의미 → 그대로 전파.
+    // 일시적 인프라 / 알 수 없는 예외 (DataAccessException 등) 만 큐로 위임.
     private void finalizePaidOrEnqueue(OrderId orderId) {
         try {
             markPaidAndPublish(orderId);
+        } catch (com.trustamarket.orderservice.order.domain.exception.OrderException e) {
+            throw e;
         } catch (RuntimeException e) {
             log.error("[saga] markPaidAndPublish 실패 — reconciliation 큐로 위임. orderId={}", orderId, e);
             reconciliationRepository.enqueueIfAbsent(
@@ -198,8 +203,10 @@ public class RequestPaymentService implements RequestPaymentUseCase {
 
     // SAGA 상태 복귀 (보상 트랜잭션 아님) — PAYMENT_PENDING → REQUESTED.
     // 1-step saga 라 wallet 에 되돌릴 외부 변경 없음. order 상태만 복귀.
-    // 본 트랜잭션이 깨지면 reconciliation 큐로 위임 + PaymentVerificationPendingException 던져 사용자에 202 응답.
-    // 호출자가 던지려던 InsufficientPointBalanceException / WalletCommunicationException 등은 도달 X —
+    //
+    // catch 분리: 도메인 결정적 예외 (OrderException) 는 그대로 전파 — retry 무의미.
+    // 일시적 인프라 / 알 수 없는 예외만 큐로 위임 + PaymentVerificationPendingException 던져 사용자에 202 응답.
+    // 후자의 경우 호출자가 던지려던 InsufficientPointBalanceException / WalletCommunicationException 등은 도달 X —
     // rollback 실패면 order 가 PAYMENT_PENDING 으로 stuck 이라 "처리 중" 응답이 더 정확.
     private void rollbackToRequested(OrderId orderId) {
         try {
@@ -211,6 +218,8 @@ public class RequestPaymentService implements RequestPaymentUseCase {
                 orderRepository.save(order);
                 return null;
             });
+        } catch (com.trustamarket.orderservice.order.domain.exception.OrderException e) {
+            throw e;
         } catch (RuntimeException e) {
             log.error("[saga] rollbackToRequested 실패 — reconciliation 큐로 위임. orderId={}", orderId, e);
             reconciliationRepository.enqueueIfAbsent(

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/reconciliation/PaymentReconciliationProcessor.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/reconciliation/PaymentReconciliationProcessor.java
@@ -131,6 +131,14 @@ public class PaymentReconciliationProcessor {
 
     // getUsage 자체가 또 실패한 경우 — 백오프 후 재시도. MAX 도달 시 GIVEN_UP + 알림.
     private void handleUnknown(PaymentReconciliation reconciliation, String error) {
+        // applyResult 의 tx2 실패로 인해 in-memory status=DONE 인 채 진입할 수 있음
+        // (tx 롤백 후에도 markDone 의 in-memory mutation 은 남음).
+        // DB 는 PENDING 그대로이므로 다음 폴링이 fresh load 후 정리하게 skip.
+        if (reconciliation.getStatus() != ReconciliationStatus.PENDING) {
+            log.warn("[Reconciliation] handleUnknown skip — in-memory status={}, orderId={}",
+                    reconciliation.getStatus(), reconciliation.getOrderId());
+            return;
+        }
         Instant now = Instant.now();
         txTemplate.execute(status -> {
             reconciliation.recordUnknown(error, now);

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/reconciliation/PaymentReconciliationProcessor.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/reconciliation/PaymentReconciliationProcessor.java
@@ -1,0 +1,143 @@
+package com.trustamarket.orderservice.order.application.service.reconciliation;
+
+import com.trustamarket.common.event.Events;
+import com.trustamarket.common.event.OutboxEvent;
+import com.trustamarket.orderservice.order.application.event.messaging.OrderEventTypes;
+import com.trustamarket.orderservice.order.application.event.messaging.OrderPaidMessage;
+import com.trustamarket.orderservice.order.application.port.out.OrderRepository;
+import com.trustamarket.orderservice.order.application.port.out.PaymentReconciliationRepository;
+import com.trustamarket.orderservice.order.application.port.out.ReconciliationAlertPort;
+import com.trustamarket.orderservice.order.application.port.out.WalletPaymentPort;
+import com.trustamarket.orderservice.order.application.port.out.WalletPaymentPort.UsageStatus;
+import com.trustamarket.orderservice.order.application.service.support.OrderHistoryRecorder;
+import com.trustamarket.orderservice.order.domain.model.Order;
+import com.trustamarket.orderservice.order.domain.model.OrderId;
+import com.trustamarket.orderservice.order.domain.model.OrderStatus;
+import com.trustamarket.orderservice.order.domain.model.PaymentReconciliation;
+import com.trustamarket.orderservice.order.domain.model.ReconciliationStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.Instant;
+import java.util.UUID;
+
+// Scheduler 가 fetch 한 reconciliation row 1건을 처리.
+// Feign 호출은 tx 밖, DB UPDATE 만 짧은 tx 안에서 — HikariCP connection 점유 시간 최소화.
+//
+// 결과 분기:
+//   DEDUCTED      → order.markPaid() + outbox + reconciliation.markDone
+//   INSUFFICIENT  → order.rollbackPaymentRequest() + reconciliation.markDone
+//   NOT_FOUND     → order.rollbackPaymentRequest() + reconciliation.markDone
+//   getUsage 실패 → reconciliation.recordUnknown (백오프) — MAX 도달 시 GIVEN_UP + 알림
+//
+// 1-step saga 이므로 wallet 에 외부 변경 되돌리는 보상 트랜잭션 없음 — order 상태 복귀만.
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentReconciliationProcessor {
+
+    private static final String DOMAIN_TYPE = "ORDER";
+
+    private final WalletPaymentPort walletPaymentPort;
+    private final OrderRepository orderRepository;
+    private final OrderHistoryRecorder historyRecorder;
+    private final PaymentReconciliationRepository reconciliationRepository;
+    private final ReconciliationAlertPort alertPort;
+    private final TransactionTemplate txTemplate;
+
+    public void processOne(PaymentReconciliation reconciliation) {
+        UUID orderIdValue = reconciliation.getOrderId();
+        UsageStatus usage;
+        try {
+            // tx 밖에서 외부 Feign 호출.
+            usage = walletPaymentPort.getUsage(orderIdValue);
+        } catch (RuntimeException e) {
+            log.warn("[Reconciliation] getUsage 실패 — orderId={}, retryCount={}, err={}",
+                    orderIdValue, reconciliation.getRetryCount(), e.toString());
+            handleUnknown(reconciliation, e.getMessage());
+            return;
+        }
+
+        try {
+            applyResult(reconciliation, usage);
+        } catch (RuntimeException e) {
+            log.error("[Reconciliation] applyResult 실패 — orderId={}, result={}",
+                    orderIdValue, usage.result(), e);
+            handleUnknown(reconciliation, e.getMessage());
+        }
+    }
+
+    // wallet 결과 (DEDUCTED / INSUFFICIENT / NOT_FOUND) 별 분기.
+    // order 상태 전이 + reconciliation.markDone 을 같은 트랜잭션 안에서 commit.
+    private void applyResult(PaymentReconciliation reconciliation, UsageStatus usage) {
+        OrderId orderId = OrderId.of(reconciliation.getOrderId());
+        txTemplate.execute(status -> {
+            switch (usage.result()) {
+                case DEDUCTED -> applyDeducted(orderId);
+                case INSUFFICIENT, NOT_FOUND -> applyRollback(orderId);
+            }
+            reconciliation.markDone(Instant.now());
+            reconciliationRepository.save(reconciliation);
+            return null;
+        });
+    }
+
+    private void applyDeducted(OrderId orderId) {
+        Order order = orderRepository.findByIdOrThrow(orderId);
+        // 이미 PAID 면 멱등 처리 — outbox 중복 발행 방지.
+        if (order.getStatus() == OrderStatus.PAID) {
+            return;
+        }
+        OrderStatus pre = order.getStatus();
+        order.markPaid();
+        historyRecorder.record(order.getId(), pre, order.getStatus(), null);
+        orderRepository.save(order);
+
+        Events.trigger(OutboxEvent.of(
+                DOMAIN_TYPE, order.getId().value(),
+                OrderEventTypes.ORDER_PAID,
+                OrderPaidMessage.of(
+                        order.getId().value(),
+                        order.getProduct().id(),
+                        order.getSeller().id(),
+                        order.getBuyer().id(),
+                        order.getType().name())));
+    }
+
+    private void applyRollback(OrderId orderId) {
+        Order order = orderRepository.findByIdOrThrow(orderId);
+        // 이미 REQUESTED 면 멱등 처리.
+        if (order.getStatus() == OrderStatus.REQUESTED) {
+            return;
+        }
+        OrderStatus pre = order.getStatus();
+        order.rollbackPaymentRequest();
+        historyRecorder.record(order.getId(), pre, order.getStatus(), null);
+        orderRepository.save(order);
+    }
+
+    // getUsage 자체가 또 실패한 경우 — 백오프 후 재시도. MAX 도달 시 GIVEN_UP + 알림.
+    private void handleUnknown(PaymentReconciliation reconciliation, String error) {
+        Instant now = Instant.now();
+        txTemplate.execute(status -> {
+            reconciliation.recordUnknown(error, now);
+            reconciliationRepository.save(reconciliation);
+            return null;
+        });
+        if (reconciliation.getStatus() == ReconciliationStatus.GIVEN_UP) {
+            try {
+                alertPort.notifyGivenUp(
+                        reconciliation.getOrderId(),
+                        reconciliation.getRetryCount(),
+                        reconciliation.getLastError()
+                );
+            } catch (RuntimeException e) {
+                // best-effort — 알림 실패가 reconciliation 자체 흐름을 막지 않게.
+                log.error("[Reconciliation] GIVEN_UP 알림 발송 실패 — orderId={}",
+                        reconciliation.getOrderId(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/reconciliation/PaymentReconciliationProcessor.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/reconciliation/PaymentReconciliationProcessor.java
@@ -70,14 +70,24 @@ public class PaymentReconciliationProcessor {
     }
 
     // wallet 결과 (DEDUCTED / INSUFFICIENT / NOT_FOUND) 별 분기.
-    // order 상태 전이 + reconciliation.markDone 을 같은 트랜잭션 안에서 commit.
+    // Aggregate 경계 (Order vs PaymentReconciliation) 분리 — 두 개의 짧은 트랜잭션으로.
+    //   tx1: Order 상태 전이 (markPaid 또는 rollbackPaymentRequest)
+    //   tx2: reconciliation.markDone
+    // tx2 실패 시 다음 폴링이 재시도 — Order 의 상태별 멱등 가드 (PAID/REQUESTED 면 skip) 가 중복 반영을 막는다.
     private void applyResult(PaymentReconciliation reconciliation, UsageStatus usage) {
         OrderId orderId = OrderId.of(reconciliation.getOrderId());
+
+        // ── tx1: Order Aggregate ──
         txTemplate.execute(status -> {
             switch (usage.result()) {
                 case DEDUCTED -> applyDeducted(orderId);
                 case INSUFFICIENT, NOT_FOUND -> applyRollback(orderId);
             }
+            return null;
+        });
+
+        // ── tx2: PaymentReconciliation Aggregate ──
+        txTemplate.execute(status -> {
             reconciliation.markDone(Instant.now());
             reconciliationRepository.save(reconciliation);
             return null;
@@ -87,6 +97,7 @@ public class PaymentReconciliationProcessor {
     private void applyDeducted(OrderId orderId) {
         Order order = orderRepository.findByIdOrThrow(orderId);
         // 이미 PAID 면 멱등 처리 — outbox 중복 발행 방지.
+        // (Aggregate 경계 분리 후 tx2 실패 시 다음 폴링에서 재진입할 때도 안전.)
         if (order.getStatus() == OrderStatus.PAID) {
             return;
         }

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/reconciliation/PaymentReconciliationProcessor.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/reconciliation/PaymentReconciliationProcessor.java
@@ -119,8 +119,10 @@ public class PaymentReconciliationProcessor {
 
     private void applyRollback(OrderId orderId) {
         Order order = orderRepository.findByIdOrThrow(orderId);
-        // 이미 REQUESTED 면 멱등 처리.
-        if (order.getStatus() == OrderStatus.REQUESTED) {
+        // 이미 REQUESTED 또는 CANCELLED 면 멱등 처리 — 종결 상태, 추가 작업 불필요.
+        // (사용자가 reconciliation 도중 cancel 한 케이스 — wallet 차감 없는 INSUFFICIENT/NOT_FOUND 라 보상 불필요.)
+        if (order.getStatus() == OrderStatus.REQUESTED
+                || order.getStatus() == OrderStatus.CANCELLED) {
             return;
         }
         OrderStatus pre = order.getStatus();

--- a/src/main/java/com/trustamarket/orderservice/order/application/service/reconciliation/PaymentReconciliationScheduler.java
+++ b/src/main/java/com/trustamarket/orderservice/order/application/service/reconciliation/PaymentReconciliationScheduler.java
@@ -1,0 +1,44 @@
+package com.trustamarket.orderservice.order.application.service.reconciliation;
+
+import com.trustamarket.orderservice.order.application.port.out.PaymentReconciliationRepository;
+import com.trustamarket.orderservice.order.domain.model.PaymentReconciliation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.List;
+
+// reconciliation 큐를 주기적으로 폴링.
+// 정상 흐름에서 row 거의 0 — 비정상 케이스 (timeout / 5xx 후 getUsage 도 실패) 만 등록됨.
+//
+// 폴링 주기 10초, 한 번에 처리할 row 수 50 으로 제한 (백프레셔).
+// 처리 자체는 Processor 에 위임 — Feign 은 tx 밖, DB UPDATE 만 짧은 tx 안.
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentReconciliationScheduler {
+
+    private static final int BATCH_SIZE = 50;
+
+    private final PaymentReconciliationRepository reconciliationRepository;
+    private final PaymentReconciliationProcessor processor;
+
+    @Scheduled(fixedDelay = 10_000)
+    public void process() {
+        List<PaymentReconciliation> targets = reconciliationRepository.findRetriable(Instant.now(), BATCH_SIZE);
+        if (targets.isEmpty()) {
+            return;
+        }
+        log.debug("[Reconciliation] 폴링 — {} rows", targets.size());
+        for (PaymentReconciliation r : targets) {
+            try {
+                processor.processOne(r);
+            } catch (RuntimeException e) {
+                // Processor 가 자체적으로 handleUnknown 까지 처리하지만, 만약 그 밖에서 던지면 다음 row 진행.
+                log.error("[Reconciliation] processOne 실패 — orderId={}", r.getOrderId(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/exception/PaymentVerificationPendingException.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/exception/PaymentVerificationPendingException.java
@@ -1,0 +1,19 @@
+package com.trustamarket.orderservice.order.domain.exception;
+
+import org.springframework.http.HttpStatus;
+
+import java.util.UUID;
+
+// 202 Accepted — 결제 결과 확인이 즉시 불가하여 비동기 재처리 (reconciliation) 위임.
+// saga 의 wallet deduct 가 timeout / 5xx 응답을 받았고, 후속 getUsage 도 실패한 케이스.
+// reconciliation 큐에 등록된 상태이므로 @Scheduled 가 백오프 (30s/60s/120s) 로 재시도한다.
+// 사용자에게 "결제 처리 중" 의미로 응답.
+public class PaymentVerificationPendingException extends OrderException {
+
+    private static final String USER_MESSAGE = "결제 처리 중입니다. 잠시 후 주문 내역에서 확인해주세요.";
+
+    public PaymentVerificationPendingException(UUID orderId, Throwable cause) {
+        super(HttpStatus.ACCEPTED, USER_MESSAGE, "order/" + orderId);
+        initCause(cause);
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/PaymentReconciliation.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/PaymentReconciliation.java
@@ -39,11 +39,14 @@ public class PaymentReconciliation {
     private Instant nextRetryAt;
     private Instant lastAttemptAt;
     private String lastError;
+    // JPA Optimistic Lock 의 version — entity 와 일관성 유지 (mapper 가 양방향 매핑).
+    // 도메인 로직에서 직접 변경하지 않음. JPA 가 entity 의 @Version 으로 자동 증가.
+    private long version;
 
     @Builder
     private PaymentReconciliation(UUID id, UUID orderId, ReconciliationStatus status,
                                   int retryCount, Instant nextRetryAt,
-                                  Instant lastAttemptAt, String lastError) {
+                                  Instant lastAttemptAt, String lastError, long version) {
         this.id = id;
         this.orderId = orderId;
         this.status = status;
@@ -51,6 +54,7 @@ public class PaymentReconciliation {
         this.nextRetryAt = nextRetryAt;
         this.lastAttemptAt = lastAttemptAt;
         this.lastError = lastError;
+        this.version = version;
     }
 
     // saga catch 안에서 결과 확인까지 실패했을 때 enqueue.

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/PaymentReconciliation.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/PaymentReconciliation.java
@@ -1,0 +1,88 @@
+package com.trustamarket.orderservice.order.domain.model;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+// p_payment_reconciliation 의 도메인 모델.
+// 결제 saga 의 wallet Feign 호출이 timeout / 5xx 등 비정상 응답을 받은 후 즉시 결과 확인 (getUsage) 까지 실패했을 때
+// enqueue 되는 재처리 row.
+//
+// 상태 전이:
+//   PENDING ─ getUsage 가 DEDUCTED / INSUFFICIENT / NOT_FOUND 중 하나로 응답 ─→ DONE
+//   PENDING ─ getUsage 가 또 실패 ─→ retry_count++, next_retry_at = NOW + BACKOFFS[retry_count]
+//   retry_count >= MAX_RETRIES (3) ─→ GIVEN_UP (운영자 알림)
+//
+// 백오프: retry_count=1 일 때 BACKOFFS[1]=60s, retry_count=2 일 때 BACKOFFS[2]=120s.
+// (retry_count=0 → enqueue 시점에 BACKOFFS[0]=30s 적용)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentReconciliation {
+
+    public static final int MAX_RETRIES = 3;
+    private static final List<Duration> BACKOFFS = List.of(
+            Duration.ofSeconds(30),
+            Duration.ofSeconds(60),
+            Duration.ofSeconds(120)
+    );
+
+    private UUID id;
+    private UUID orderId;
+    private ReconciliationStatus status;
+    private int retryCount;
+    private Instant nextRetryAt;
+    private Instant lastAttemptAt;
+    private String lastError;
+
+    @Builder
+    private PaymentReconciliation(UUID id, UUID orderId, ReconciliationStatus status,
+                                  int retryCount, Instant nextRetryAt,
+                                  Instant lastAttemptAt, String lastError) {
+        this.id = id;
+        this.orderId = orderId;
+        this.status = status;
+        this.retryCount = retryCount;
+        this.nextRetryAt = nextRetryAt;
+        this.lastAttemptAt = lastAttemptAt;
+        this.lastError = lastError;
+    }
+
+    // saga catch 안에서 결과 확인까지 실패했을 때 enqueue.
+    // 첫 폴링 시점: NOW + BACKOFFS[0] (30s).
+    public static PaymentReconciliation enqueue(UUID orderId, Instant now) {
+        return PaymentReconciliation.builder()
+                .id(UUID.randomUUID())
+                .orderId(orderId)
+                .status(ReconciliationStatus.PENDING)
+                .retryCount(0)
+                .nextRetryAt(now.plus(BACKOFFS.get(0)))
+                .build();
+    }
+
+    // 결과 확인 성공 — DEDUCTED / INSUFFICIENT / NOT_FOUND 어떤 응답이든 처리 끝.
+    // 어떤 결과로 종료됐는지는 호출자가 별도 분기 (markPaid / rollbackToRequested).
+    public void markDone(Instant now) {
+        this.status = ReconciliationStatus.DONE;
+        this.lastAttemptAt = now;
+    }
+
+    // 결과 확인 자체가 실패 — 다음 시도까지 백오프.
+    // retry_count 가 MAX_RETRIES 도달 시 GIVEN_UP (운영자 알림 대상).
+    public void recordUnknown(String error, Instant now) {
+        this.retryCount += 1;
+        this.lastAttemptAt = now;
+        this.lastError = error;
+        if (this.retryCount >= MAX_RETRIES) {
+            this.status = ReconciliationStatus.GIVEN_UP;
+        } else {
+            int idx = Math.min(this.retryCount, BACKOFFS.size() - 1);
+            this.nextRetryAt = now.plus(BACKOFFS.get(idx));
+        }
+    }
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/ReconciliationStatus.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/ReconciliationStatus.java
@@ -1,0 +1,11 @@
+package com.trustamarket.orderservice.order.domain.model;
+
+// PaymentReconciliation 의 상태.
+// PENDING:   재시도 대기. polling 이 next_retry_at <= NOW() 조건으로 fetch.
+// DONE:      DEDUCTED 또는 NOT_DEDUCTED 결과를 받아 처리 완료. 추가 폴링 X.
+// GIVEN_UP:  retry_count 가 MAX_RETRIES (3) 도달. 운영자 (Discord webhook) 알림 후 수동 처리.
+public enum ReconciliationStatus {
+    PENDING,
+    DONE,
+    GIVEN_UP
+}

--- a/src/main/java/com/trustamarket/orderservice/order/domain/model/ReconciliationStatus.java
+++ b/src/main/java/com/trustamarket/orderservice/order/domain/model/ReconciliationStatus.java
@@ -2,7 +2,7 @@ package com.trustamarket.orderservice.order.domain.model;
 
 // PaymentReconciliation 의 상태.
 // PENDING:   재시도 대기. polling 이 next_retry_at <= NOW() 조건으로 fetch.
-// DONE:      DEDUCTED 또는 NOT_DEDUCTED 결과를 받아 처리 완료. 추가 폴링 X.
+// DONE:      DEDUCTED / INSUFFICIENT / NOT_FOUND 결과를 받아 처리 완료. 추가 폴링 X.
 // GIVEN_UP:  retry_count 가 MAX_RETRIES (3) 도달. 운영자 (Discord webhook) 알림 후 수동 처리.
 public enum ReconciliationStatus {
     PENDING,

--- a/src/main/resources/db/changelog/007-create-p-payment-reconciliation.yaml
+++ b/src/main/resources/db/changelog/007-create-p-payment-reconciliation.yaml
@@ -89,11 +89,12 @@ databaseChangeLog:
                   type: uuid
 
         # polling 쿼리: WHERE status='PENDING' AND next_retry_at <= NOW()
-        - createIndex:
-            tableName: p_payment_reconciliation
-            indexName: idx_p_payment_reconciliation_status_next_retry_at
-            columns:
-              - column:
-                  name: status
-              - column:
-                  name: next_retry_at
+        # PENDING 외 상태 (DONE / GIVEN_UP) 는 polling 대상 아니므로 partial index 로 크기 축소.
+        # Liquibase createIndex 는 partial 지원 X → raw SQL 사용 (PostgreSQL).
+        - sql:
+            dbms: postgresql
+            sql: >-
+              CREATE INDEX idx_p_payment_reconciliation_pending_next_retry_at
+              ON p_payment_reconciliation (next_retry_at)
+              WHERE status = 'PENDING';
+            rollback: DROP INDEX IF EXISTS idx_p_payment_reconciliation_pending_next_retry_at;

--- a/src/main/resources/db/changelog/007-create-p-payment-reconciliation.yaml
+++ b/src/main/resources/db/changelog/007-create-p-payment-reconciliation.yaml
@@ -57,6 +57,15 @@ databaseChangeLog:
                   name: last_error
                   type: text
 
+              # Optimistic Lock — multi-pod 또는 동시 폴링 시 같은 row 의 마지막 commit 덮어쓰기 방지.
+              # JPA @Version 이 매 UPDATE 마다 WHERE version = :v 조건 추가 + 충돌 시 OptimisticLockException.
+              - column:
+                  name: version
+                  type: bigint
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+
               # audit (BaseUserEntity 일관성) — 시스템 처리라 by 는 system UUID 또는 null.
               - column:
                   name: created_at

--- a/src/main/resources/db/changelog/007-create-p-payment-reconciliation.yaml
+++ b/src/main/resources/db/changelog/007-create-p-payment-reconciliation.yaml
@@ -1,0 +1,90 @@
+databaseChangeLog:
+  - changeSet:
+      id: 007-create-p-payment-reconciliation
+      author: lhk
+      changes:
+        # saga 의 wallet Feign 호출이 timeout / 5xx 등 비정상 응답을 받았을 때
+        # 결과 확인을 즉시 못 한 케이스에 대해 DB queue 로 재시도를 관리.
+        # 1 order = 1 row (UNIQUE order_id) — 중복 등록 방지.
+        - createTable:
+            tableName: p_payment_reconciliation
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+
+              - column:
+                  name: order_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    unique: true
+                    uniqueConstraintName: uq_p_payment_reconciliation_order_id
+
+              # PENDING (재시도 대기) → DONE (완료, DEDUCTED 또는 NOT_DEDUCTED 처리됨) / GIVEN_UP (3회 초과)
+              - column:
+                  name: status
+                  type: varchar(20)
+                  defaultValue: PENDING
+                  constraints:
+                    nullable: false
+
+              # 0 시작. 1, 2 시도 후 3 도달 시 GIVEN_UP.
+              - column:
+                  name: retry_count
+                  type: int
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+
+              # 다음 시도 시각. polling 이 NOW() 와 비교.
+              - column:
+                  name: next_retry_at
+                  type: timestamptz
+                  constraints:
+                    nullable: false
+
+              # 마지막 시도 시각 (성공/실패 모두 기록).
+              - column:
+                  name: last_attempt_at
+                  type: timestamptz
+
+              # 마지막 시도의 실패 사유 (timeout / 5xx 등).
+              - column:
+                  name: last_error
+                  type: text
+
+              # audit (BaseUserEntity 일관성) — 시스템 처리라 by 는 system UUID 또는 null.
+              - column:
+                  name: created_at
+                  type: timestamptz
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_by
+                  type: uuid
+              - column:
+                  name: updated_at
+                  type: timestamptz
+              - column:
+                  name: updated_by
+                  type: uuid
+              - column:
+                  name: deleted_at
+                  type: timestamptz
+              - column:
+                  name: deleted_by
+                  type: uuid
+
+        # polling 쿼리: WHERE status='PENDING' AND next_retry_at <= NOW()
+        - createIndex:
+            tableName: p_payment_reconciliation
+            indexName: idx_p_payment_reconciliation_status_next_retry_at
+            columns:
+              - column:
+                  name: status
+              - column:
+                  name: next_retry_at

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -11,3 +11,5 @@ databaseChangeLog:
       file: db/changelog/005-alter-p-order-inbox-composite-unique.yaml
   - include:
       file: db/changelog/006-rename-order-status-refund-to-cancellation.yaml
+  - include:
+      file: db/changelog/007-create-p-payment-reconciliation.yaml

--- a/src/test/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletPaymentAdapterTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/adapter/out/wallet/WalletPaymentAdapterTest.java
@@ -34,7 +34,7 @@ class WalletPaymentAdapterTest {
         when(walletFeignClient.usePoint(any()))
                 .thenReturn(ResponseEntity.ok(CommonResponse.of(200, walletResp)));
 
-        DeductPointResponse result = adapter.deduct(new DeductPointRequest(orderId, buyerId, 500_000L));
+        DeductPointResponse result = adapter.deduct(new DeductPointRequest(UUID.randomUUID(), orderId, buyerId, 500_000L));
 
         assertThat(result.balance()).isEqualTo(9_500_000L);
         assertThat(result.shortage()).isNull();
@@ -46,7 +46,7 @@ class WalletPaymentAdapterTest {
         when(walletFeignClient.usePoint(any()))
                 .thenReturn(null);
 
-        assertThatThrownBy(() -> adapter.deduct(new DeductPointRequest(UUID.randomUUID(), UUID.randomUUID(), 100L)))
+        assertThatThrownBy(() -> adapter.deduct(new DeductPointRequest(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), 100L)))
                 .isInstanceOf(WalletCommunicationException.class);
     }
 
@@ -56,7 +56,7 @@ class WalletPaymentAdapterTest {
         when(walletFeignClient.usePoint(any()))
                 .thenReturn(ResponseEntity.ok(null));
 
-        assertThatThrownBy(() -> adapter.deduct(new DeductPointRequest(UUID.randomUUID(), UUID.randomUUID(), 100L)))
+        assertThatThrownBy(() -> adapter.deduct(new DeductPointRequest(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), 100L)))
                 .isInstanceOf(WalletCommunicationException.class);
     }
 
@@ -66,7 +66,7 @@ class WalletPaymentAdapterTest {
         when(walletFeignClient.usePoint(any()))
                 .thenReturn(ResponseEntity.ok(CommonResponse.of(200, null)));
 
-        assertThatThrownBy(() -> adapter.deduct(new DeductPointRequest(UUID.randomUUID(), UUID.randomUUID(), 100L)))
+        assertThatThrownBy(() -> adapter.deduct(new DeductPointRequest(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), 100L)))
                 .isInstanceOf(WalletCommunicationException.class);
     }
 
@@ -77,7 +77,7 @@ class WalletPaymentAdapterTest {
         when(walletFeignClient.usePoint(any()))
                 .thenReturn(ResponseEntity.ok(CommonResponse.of(200, walletResp)));
 
-        assertThatThrownBy(() -> adapter.deduct(new DeductPointRequest(UUID.randomUUID(), UUID.randomUUID(), 100L)))
+        assertThatThrownBy(() -> adapter.deduct(new DeductPointRequest(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), 100L)))
                 .isInstanceOf(WalletCommunicationException.class);
     }
 
@@ -88,7 +88,7 @@ class WalletPaymentAdapterTest {
         when(walletFeignClient.usePoint(any()))
                 .thenReturn(ResponseEntity.ok(CommonResponse.of(200, walletResp)));
 
-        assertThatThrownBy(() -> adapter.deduct(new DeductPointRequest(UUID.randomUUID(), UUID.randomUUID(), 100L)))
+        assertThatThrownBy(() -> adapter.deduct(new DeductPointRequest(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), 100L)))
                 .isInstanceOf(WalletCommunicationException.class);
     }
 }

--- a/src/test/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentServiceTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentServiceTest.java
@@ -197,8 +197,8 @@ class RequestPaymentServiceTest {
     }
 
     @Test
-    @DisplayName("rollbackToRequested tx 실패 → reconciliation 큐로 위임 (안전망)")
-    void rollback_txFailure_enqueuesReconciliation() {
+    @DisplayName("rollbackToRequested tx 실패 → reconciliation 큐 위임 + PaymentVerificationPendingException (안전망)")
+    void rollback_txFailure_enqueuesAndPending() {
         UUID buyerId = UUID.randomUUID();
         String idempotencyKey = UUID.randomUUID().toString();
         Order order = OrderTestFixtures.requestedOrder(buyerId, UUID.randomUUID());
@@ -212,10 +212,33 @@ class RequestPaymentServiceTest {
                 .doThrow(new RuntimeException("DB 일시 장애"));
         stubber.when(orderRepository).save(any(Order.class));
 
-        // saga 본문은 InsufficientPointBalanceException 을 던지지만, rollback 실패 → 큐 위임 → 그대로 throw.
+        // rollback 실패 → 호출자의 InsufficientPointBalanceException 은 unreachable.
+        // 큐 위임 + PaymentVerificationPendingException 으로 사용자에 "처리 중" 응답.
         assertThatThrownBy(() ->
                 service.requestPayment(new RequestPaymentCommand(order.getId().value(), buyerId, idempotencyKey))
-        ).isInstanceOf(InsufficientPointBalanceException.class);
+        ).isInstanceOf(PaymentVerificationPendingException.class);
+
+        verify(reconciliationRepository).enqueueIfAbsent(any(PaymentReconciliation.class));
+    }
+
+    @Test
+    @DisplayName("deduct 성공 후 markPaidAndPublish (tx2) 실패 → reconciliation 큐 위임 + PaymentVerificationPendingException")
+    void tx2Failure_enqueuesAndPending() {
+        UUID buyerId = UUID.randomUUID();
+        String idempotencyKey = UUID.randomUUID().toString();
+        Order order = OrderTestFixtures.requestedOrder(buyerId, UUID.randomUUID());
+        when(inboxRepository.tryRecordIdempotencyKey(idempotencyKey, InboxPurposeKey.REQUEST_PAYMENT)).thenReturn(true);
+        when(orderRepository.findByIdOrThrow(order.getId())).thenReturn(order);
+        when(walletPaymentPort.deduct(any())).thenReturn(new DeductPointResponse(50_000L, null));
+        // 첫 번째 save (PAYMENT_PENDING) 성공, 두 번째 save (PAID) 실패 시뮬.
+        org.mockito.stubbing.Stubber stubber = org.mockito.Mockito.doAnswer(inv -> inv.getArgument(0))
+                .doThrow(new RuntimeException("DB 일시 장애"));
+        stubber.when(orderRepository).save(any(Order.class));
+
+        // wallet 은 이미 차감됨. tx2 실패가 영구 stuck 되지 않도록 큐 위임 + 202 응답.
+        assertThatThrownBy(() ->
+                service.requestPayment(new RequestPaymentCommand(order.getId().value(), buyerId, idempotencyKey))
+        ).isInstanceOf(PaymentVerificationPendingException.class);
 
         verify(reconciliationRepository).enqueueIfAbsent(any(PaymentReconciliation.class));
     }

--- a/src/test/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentServiceTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentServiceTest.java
@@ -5,13 +5,18 @@ import com.trustamarket.orderservice.order.application.port.in.RequestPaymentUse
 import com.trustamarket.orderservice.order.application.port.out.InboxRepository;
 import com.trustamarket.orderservice.order.application.port.out.InboxRepository.InboxPurposeKey;
 import com.trustamarket.orderservice.order.application.port.out.OrderRepository;
+import com.trustamarket.orderservice.order.application.port.out.PaymentReconciliationRepository;
 import com.trustamarket.orderservice.order.application.port.out.WalletPaymentPort;
 import com.trustamarket.orderservice.order.application.port.out.WalletPaymentPort.DeductPointResponse;
+import com.trustamarket.orderservice.order.application.port.out.WalletPaymentPort.UsageStatus;
 import com.trustamarket.orderservice.order.application.service.OrderTestFixtures;
 import com.trustamarket.orderservice.order.application.service.support.OrderHistoryRecorder;
 import com.trustamarket.orderservice.order.domain.exception.InsufficientPointBalanceException;
+import com.trustamarket.orderservice.order.domain.exception.PaymentVerificationPendingException;
+import com.trustamarket.orderservice.order.domain.exception.WalletCommunicationException;
 import com.trustamarket.orderservice.order.domain.model.Order;
 import com.trustamarket.orderservice.order.domain.model.OrderStatus;
+import com.trustamarket.orderservice.order.domain.model.PaymentReconciliation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,6 +45,7 @@ class RequestPaymentServiceTest {
     @Mock OrderHistoryRecorder historyRecorder;
     @Mock WalletPaymentPort walletPaymentPort;
     @Mock InboxRepository inboxRepository;
+    @Mock PaymentReconciliationRepository reconciliationRepository;
     @Mock TransactionTemplate txTemplate;
     @InjectMocks RequestPaymentService service;
 
@@ -124,6 +130,92 @@ class RequestPaymentServiceTest {
         verify(walletPaymentPort, never()).deduct(any());
         verify(historyRecorder, never()).record(any(), any(), any(), any());
         verify(orderRepository, never()).save(any());
+    }
+
+    // ── 비정상 응답 (timeout / 5xx) — getUsage 재확인 분기 ──
+
+    @Test
+    @DisplayName("wallet timeout → getUsage=DEDUCTED → PAID 진행")
+    void unknown_thenDeducted() {
+        UUID buyerId = UUID.randomUUID();
+        String idempotencyKey = UUID.randomUUID().toString();
+        Order order = OrderTestFixtures.requestedOrder(buyerId, UUID.randomUUID());
+        when(inboxRepository.tryRecordIdempotencyKey(idempotencyKey, InboxPurposeKey.REQUEST_PAYMENT)).thenReturn(true);
+        when(orderRepository.findByIdOrThrow(order.getId())).thenReturn(order);
+        when(walletPaymentPort.deduct(any())).thenThrow(new WalletCommunicationException());
+        when(walletPaymentPort.getUsage(order.getId().value())).thenReturn(
+                new UsageStatus(order.getId().value(), UsageStatus.Result.DEDUCTED,
+                        100_000L, 50_000L, null, java.time.Instant.now()));
+
+        service.requestPayment(new RequestPaymentCommand(order.getId().value(), buyerId, idempotencyKey));
+
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.PAID);
+        // PAYMENT_PENDING save + PAID save = 2번 (rollback 없음)
+        verify(orderRepository, times(2)).save(order);
+    }
+
+    @Test
+    @DisplayName("wallet timeout → getUsage=INSUFFICIENT → InsufficientPointBalanceException + REQUESTED 복귀")
+    void unknown_thenInsufficient() {
+        UUID buyerId = UUID.randomUUID();
+        String idempotencyKey = UUID.randomUUID().toString();
+        Order order = OrderTestFixtures.requestedOrder(buyerId, UUID.randomUUID());
+        when(inboxRepository.tryRecordIdempotencyKey(idempotencyKey, InboxPurposeKey.REQUEST_PAYMENT)).thenReturn(true);
+        when(orderRepository.findByIdOrThrow(order.getId())).thenReturn(order);
+        when(walletPaymentPort.deduct(any())).thenThrow(new WalletCommunicationException());
+        when(walletPaymentPort.getUsage(order.getId().value())).thenReturn(
+                new UsageStatus(order.getId().value(), UsageStatus.Result.INSUFFICIENT,
+                        null, 5_000L, 95_000L, null));
+
+        assertThatThrownBy(() ->
+                service.requestPayment(new RequestPaymentCommand(order.getId().value(), buyerId, idempotencyKey))
+        ).isInstanceOf(InsufficientPointBalanceException.class);
+
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.REQUESTED);
+        verify(orderRepository, times(2)).save(any(Order.class));
+    }
+
+    @Test
+    @DisplayName("wallet timeout → getUsage=NOT_FOUND → WalletCommunicationException + REQUESTED 복귀")
+    void unknown_thenNotFound() {
+        UUID buyerId = UUID.randomUUID();
+        String idempotencyKey = UUID.randomUUID().toString();
+        Order order = OrderTestFixtures.requestedOrder(buyerId, UUID.randomUUID());
+        when(inboxRepository.tryRecordIdempotencyKey(idempotencyKey, InboxPurposeKey.REQUEST_PAYMENT)).thenReturn(true);
+        when(orderRepository.findByIdOrThrow(order.getId())).thenReturn(order);
+        when(walletPaymentPort.deduct(any())).thenThrow(new WalletCommunicationException());
+        when(walletPaymentPort.getUsage(order.getId().value())).thenReturn(
+                new UsageStatus(order.getId().value(), UsageStatus.Result.NOT_FOUND,
+                        null, null, null, null));
+
+        assertThatThrownBy(() ->
+                service.requestPayment(new RequestPaymentCommand(order.getId().value(), buyerId, idempotencyKey))
+        ).isInstanceOf(WalletCommunicationException.class);
+
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.REQUESTED);
+        verify(orderRepository, times(2)).save(any(Order.class));
+    }
+
+    @Test
+    @DisplayName("wallet timeout → getUsage 도 실패 → reconciliation enqueue + PaymentVerificationPendingException")
+    void unknown_verifyAlsoFails() {
+        UUID buyerId = UUID.randomUUID();
+        String idempotencyKey = UUID.randomUUID().toString();
+        Order order = OrderTestFixtures.requestedOrder(buyerId, UUID.randomUUID());
+        when(inboxRepository.tryRecordIdempotencyKey(idempotencyKey, InboxPurposeKey.REQUEST_PAYMENT)).thenReturn(true);
+        when(orderRepository.findByIdOrThrow(order.getId())).thenReturn(order);
+        when(walletPaymentPort.deduct(any())).thenThrow(new WalletCommunicationException());
+        when(walletPaymentPort.getUsage(order.getId().value())).thenThrow(new WalletCommunicationException());
+
+        assertThatThrownBy(() ->
+                service.requestPayment(new RequestPaymentCommand(order.getId().value(), buyerId, idempotencyKey))
+        ).isInstanceOf(PaymentVerificationPendingException.class);
+
+        // PAYMENT_PENDING 으로 남음 (rollback X)
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.PAYMENT_PENDING);
+        verify(reconciliationRepository).enqueueIfAbsent(any(PaymentReconciliation.class));
+        // PAYMENT_PENDING save 만, rollback save 없음
+        verify(orderRepository, times(1)).save(order);
     }
 
     @Test

--- a/src/test/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentServiceTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentServiceTest.java
@@ -222,6 +222,27 @@ class RequestPaymentServiceTest {
     }
 
     @Test
+    @DisplayName("tx2 도메인 예외 (markPaidAndPublish 안 OrderNotFoundException) → 큐 위임 + PaymentVerificationPendingException")
+    void tx2DomainException_enqueuesAndPending() {
+        UUID buyerId = UUID.randomUUID();
+        String idempotencyKey = UUID.randomUUID().toString();
+        Order order = OrderTestFixtures.requestedOrder(buyerId, UUID.randomUUID());
+        when(inboxRepository.tryRecordIdempotencyKey(idempotencyKey, InboxPurposeKey.REQUEST_PAYMENT)).thenReturn(true);
+        // tx1 의 findByIdOrThrow 는 성공, tx2 (markPaidAndPublish 안) 의 findByIdOrThrow 는 도메인 예외.
+        when(orderRepository.findByIdOrThrow(order.getId()))
+                .thenReturn(order)
+                .thenThrow(new com.trustamarket.orderservice.order.domain.exception.OrderNotFoundException(order.getId().value()));
+        when(walletPaymentPort.deduct(any())).thenReturn(new DeductPointResponse(50_000L, null));
+
+        // wallet 차감된 상태에서 도메인 예외로 throw 하면 영구 stuck 가능 → 큐로 위임 + 202 응답.
+        assertThatThrownBy(() ->
+                service.requestPayment(new RequestPaymentCommand(order.getId().value(), buyerId, idempotencyKey))
+        ).isInstanceOf(PaymentVerificationPendingException.class);
+
+        verify(reconciliationRepository).enqueueIfAbsent(any(PaymentReconciliation.class));
+    }
+
+    @Test
     @DisplayName("deduct 성공 후 markPaidAndPublish (tx2) 실패 → reconciliation 큐 위임 + PaymentVerificationPendingException")
     void tx2Failure_enqueuesAndPending() {
         UUID buyerId = UUID.randomUUID();

--- a/src/test/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentServiceTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/application/service/command/RequestPaymentServiceTest.java
@@ -197,6 +197,30 @@ class RequestPaymentServiceTest {
     }
 
     @Test
+    @DisplayName("rollbackToRequested tx 실패 → reconciliation 큐로 위임 (안전망)")
+    void rollback_txFailure_enqueuesReconciliation() {
+        UUID buyerId = UUID.randomUUID();
+        String idempotencyKey = UUID.randomUUID().toString();
+        Order order = OrderTestFixtures.requestedOrder(buyerId, UUID.randomUUID());
+        when(inboxRepository.tryRecordIdempotencyKey(idempotencyKey, InboxPurposeKey.REQUEST_PAYMENT)).thenReturn(true);
+        when(orderRepository.findByIdOrThrow(order.getId())).thenReturn(order);
+        // 정상 응답: 잔액 부족 → rollbackToRequested 시도
+        when(walletPaymentPort.deduct(any())).thenReturn(new DeductPointResponse(5_000L, 98_000L));
+        // 두 번째 tx (rollback 의 save) 가 일시 장애로 실패하도록 stub.
+        // 첫 번째 save (PAYMENT_PENDING) 는 성공, 두 번째 save 가 RuntimeException.
+        org.mockito.stubbing.Stubber stubber = org.mockito.Mockito.doAnswer(inv -> inv.getArgument(0))
+                .doThrow(new RuntimeException("DB 일시 장애"));
+        stubber.when(orderRepository).save(any(Order.class));
+
+        // saga 본문은 InsufficientPointBalanceException 을 던지지만, rollback 실패 → 큐 위임 → 그대로 throw.
+        assertThatThrownBy(() ->
+                service.requestPayment(new RequestPaymentCommand(order.getId().value(), buyerId, idempotencyKey))
+        ).isInstanceOf(InsufficientPointBalanceException.class);
+
+        verify(reconciliationRepository).enqueueIfAbsent(any(PaymentReconciliation.class));
+    }
+
+    @Test
     @DisplayName("wallet timeout → getUsage 도 실패 → reconciliation enqueue + PaymentVerificationPendingException")
     void unknown_verifyAlsoFails() {
         UUID buyerId = UUID.randomUUID();

--- a/src/test/java/com/trustamarket/orderservice/order/application/service/reconciliation/PaymentReconciliationProcessorTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/application/service/reconciliation/PaymentReconciliationProcessorTest.java
@@ -157,6 +157,26 @@ class PaymentReconciliationProcessorTest {
     }
 
     @Test
+    @DisplayName("INSUFFICIENT 인데 order 가 이미 CANCELLED — 멱등 처리 (rollback 호출 X)")
+    void insufficient_alreadyCancelled() {
+        Order order = OrderTestFixtures.requestedOrder();
+        order.requestPayment();   // REQUESTED → PAYMENT_PENDING
+        order.cancel(com.trustamarket.orderservice.order.domain.model.Reason.of("user cancelled during reconciliation"));
+        PaymentReconciliation r = PaymentReconciliation.enqueue(order.getId().value(), Instant.now());
+        when(walletPaymentPort.getUsage(order.getId().value())).thenReturn(
+                new UsageStatus(order.getId().value(), UsageStatus.Result.INSUFFICIENT,
+                        null, 5_000L, 95_000L, null));
+        when(orderRepository.findByIdOrThrow(order.getId())).thenReturn(order);
+
+        processor.processOne(r);
+
+        // CANCELLED 종결 상태 유지 — rollback 안 함 (wallet 차감 없는 케이스라 보상 불필요)
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+        assertThat(r.getStatus()).isEqualTo(ReconciliationStatus.DONE);
+        verify(orderRepository, never()).save(any(Order.class));
+    }
+
+    @Test
     @DisplayName("DEDUCTED 인데 order 가 이미 PAID — 멱등 처리 (markPaid 호출 X)")
     void deducted_alreadyPaid() {
         Order order = OrderTestFixtures.paidOrder(UUID.randomUUID(), UUID.randomUUID());

--- a/src/test/java/com/trustamarket/orderservice/order/application/service/reconciliation/PaymentReconciliationProcessorTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/application/service/reconciliation/PaymentReconciliationProcessorTest.java
@@ -27,6 +27,8 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -154,8 +156,4 @@ class PaymentReconciliationProcessorTest {
         order.requestPayment();    // REQUESTED → PAYMENT_PENDING
         return order;
     }
-
-    // Mockito ArgumentMatchers 헬퍼 static import 누락 회피 — 메서드 정의로 대체.
-    private static <T> T eq(T value) { return org.mockito.ArgumentMatchers.eq(value); }
-    private static int anyInt() { return org.mockito.ArgumentMatchers.anyInt(); }
 }

--- a/src/test/java/com/trustamarket/orderservice/order/application/service/reconciliation/PaymentReconciliationProcessorTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/application/service/reconciliation/PaymentReconciliationProcessorTest.java
@@ -133,26 +133,26 @@ class PaymentReconciliationProcessorTest {
     }
 
     @Test
-    @DisplayName("tx2 reconciliation save 실패 → handleUnknown 으로 retry_count++ (회귀)")
-    void tx2Failure_handleUnknownFallback() {
+    @DisplayName("tx2 reconciliation save 실패 → in-memory DONE 가드로 handleUnknown skip (회귀)")
+    void tx2Failure_skipsHandleUnknown() {
         Order order = paymentPendingOrder();
         PaymentReconciliation r = PaymentReconciliation.enqueue(order.getId().value(), Instant.now());
         when(walletPaymentPort.getUsage(order.getId().value())).thenReturn(
                 new UsageStatus(order.getId().value(), UsageStatus.Result.DEDUCTED,
                         100_000L, 50_000L, null, Instant.now()));
         when(orderRepository.findByIdOrThrow(order.getId())).thenReturn(order);
-        // tx2 의 첫 save (markDone 직후) 만 throw, 두 번째 save (handleUnknown 의 recordUnknown 후) 는 성공.
-        org.mockito.stubbing.Stubber stubber = org.mockito.Mockito.doThrow(new RuntimeException("DB 일시 장애"))
-                .doAnswer(inv -> inv.getArgument(0));
-        stubber.when(reconciliationRepository).save(any(PaymentReconciliation.class));
+        // tx2 의 save 가 실패 — in-memory 는 markDone 으로 status=DONE 이지만 DB 는 PENDING.
+        org.mockito.Mockito.doThrow(new RuntimeException("DB 일시 장애"))
+                .when(reconciliationRepository).save(any(PaymentReconciliation.class));
 
         processor.processOne(r);
 
         // tx1 은 commit 되어 Order 는 PAID — 다음 폴링에서 멱등 가드가 중복 반영 방지.
         assertThat(order.getStatus()).isEqualTo(OrderStatus.PAID);
-        // tx2 실패 → handleUnknown → recordUnknown 으로 retry_count 증가.
-        assertThat(r.getRetryCount()).isEqualTo(1);
-        // 첫 시도라 GIVEN_UP / 알림 발생 X.
+        // in-memory status 는 markDone 호출된 채 남아있음.
+        assertThat(r.getStatus()).isEqualTo(ReconciliationStatus.DONE);
+        // handleUnknown 가드가 작동 — recordUnknown 호출 X → retry_count 0 유지.
+        assertThat(r.getRetryCount()).isEqualTo(0);
         verify(alertPort, never()).notifyGivenUp(any(), anyInt(), any());
     }
 

--- a/src/test/java/com/trustamarket/orderservice/order/application/service/reconciliation/PaymentReconciliationProcessorTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/application/service/reconciliation/PaymentReconciliationProcessorTest.java
@@ -133,6 +133,30 @@ class PaymentReconciliationProcessorTest {
     }
 
     @Test
+    @DisplayName("tx2 reconciliation save 실패 → handleUnknown 으로 retry_count++ (회귀)")
+    void tx2Failure_handleUnknownFallback() {
+        Order order = paymentPendingOrder();
+        PaymentReconciliation r = PaymentReconciliation.enqueue(order.getId().value(), Instant.now());
+        when(walletPaymentPort.getUsage(order.getId().value())).thenReturn(
+                new UsageStatus(order.getId().value(), UsageStatus.Result.DEDUCTED,
+                        100_000L, 50_000L, null, Instant.now()));
+        when(orderRepository.findByIdOrThrow(order.getId())).thenReturn(order);
+        // tx2 의 첫 save (markDone 직후) 만 throw, 두 번째 save (handleUnknown 의 recordUnknown 후) 는 성공.
+        org.mockito.stubbing.Stubber stubber = org.mockito.Mockito.doThrow(new RuntimeException("DB 일시 장애"))
+                .doAnswer(inv -> inv.getArgument(0));
+        stubber.when(reconciliationRepository).save(any(PaymentReconciliation.class));
+
+        processor.processOne(r);
+
+        // tx1 은 commit 되어 Order 는 PAID — 다음 폴링에서 멱등 가드가 중복 반영 방지.
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.PAID);
+        // tx2 실패 → handleUnknown → recordUnknown 으로 retry_count 증가.
+        assertThat(r.getRetryCount()).isEqualTo(1);
+        // 첫 시도라 GIVEN_UP / 알림 발생 X.
+        verify(alertPort, never()).notifyGivenUp(any(), anyInt(), any());
+    }
+
+    @Test
     @DisplayName("DEDUCTED 인데 order 가 이미 PAID — 멱등 처리 (markPaid 호출 X)")
     void deducted_alreadyPaid() {
         Order order = OrderTestFixtures.paidOrder(UUID.randomUUID(), UUID.randomUUID());

--- a/src/test/java/com/trustamarket/orderservice/order/application/service/reconciliation/PaymentReconciliationProcessorTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/application/service/reconciliation/PaymentReconciliationProcessorTest.java
@@ -1,0 +1,161 @@
+package com.trustamarket.orderservice.order.application.service.reconciliation;
+
+import com.trustamarket.orderservice.order.application.port.out.OrderRepository;
+import com.trustamarket.orderservice.order.application.port.out.PaymentReconciliationRepository;
+import com.trustamarket.orderservice.order.application.port.out.ReconciliationAlertPort;
+import com.trustamarket.orderservice.order.application.port.out.WalletPaymentPort;
+import com.trustamarket.orderservice.order.application.port.out.WalletPaymentPort.UsageStatus;
+import com.trustamarket.orderservice.order.application.service.OrderTestFixtures;
+import com.trustamarket.orderservice.order.application.service.support.OrderHistoryRecorder;
+import com.trustamarket.orderservice.order.domain.exception.WalletCommunicationException;
+import com.trustamarket.orderservice.order.domain.model.Order;
+import com.trustamarket.orderservice.order.domain.model.OrderStatus;
+import com.trustamarket.orderservice.order.domain.model.PaymentReconciliation;
+import com.trustamarket.orderservice.order.domain.model.ReconciliationStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentReconciliationProcessorTest {
+
+    @Mock WalletPaymentPort walletPaymentPort;
+    @Mock OrderRepository orderRepository;
+    @Mock OrderHistoryRecorder historyRecorder;
+    @Mock PaymentReconciliationRepository reconciliationRepository;
+    @Mock ReconciliationAlertPort alertPort;
+    @Mock TransactionTemplate txTemplate;
+    @InjectMocks PaymentReconciliationProcessor processor;
+
+    @BeforeEach
+    void setUpTxTemplate() {
+        lenient().when(txTemplate.execute(any())).thenAnswer(inv -> {
+            TransactionCallback<?> cb = inv.getArgument(0);
+            return cb.doInTransaction(null);
+        });
+    }
+
+    @Test
+    @DisplayName("DEDUCTED — markPaid + reconciliation DONE")
+    void deducted() {
+        Order order = paymentPendingOrder();
+        PaymentReconciliation r = PaymentReconciliation.enqueue(order.getId().value(), Instant.now());
+        when(walletPaymentPort.getUsage(order.getId().value())).thenReturn(
+                new UsageStatus(order.getId().value(), UsageStatus.Result.DEDUCTED,
+                        100_000L, 50_000L, null, Instant.now()));
+        when(orderRepository.findByIdOrThrow(order.getId())).thenReturn(order);
+
+        processor.processOne(r);
+
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.PAID);
+        assertThat(r.getStatus()).isEqualTo(ReconciliationStatus.DONE);
+        verify(reconciliationRepository).save(r);
+    }
+
+    @Test
+    @DisplayName("INSUFFICIENT — rollbackToRequested + reconciliation DONE")
+    void insufficient() {
+        Order order = paymentPendingOrder();
+        PaymentReconciliation r = PaymentReconciliation.enqueue(order.getId().value(), Instant.now());
+        when(walletPaymentPort.getUsage(order.getId().value())).thenReturn(
+                new UsageStatus(order.getId().value(), UsageStatus.Result.INSUFFICIENT,
+                        null, 5_000L, 95_000L, null));
+        when(orderRepository.findByIdOrThrow(order.getId())).thenReturn(order);
+
+        processor.processOne(r);
+
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.REQUESTED);
+        assertThat(r.getStatus()).isEqualTo(ReconciliationStatus.DONE);
+    }
+
+    @Test
+    @DisplayName("NOT_FOUND — rollbackToRequested + reconciliation DONE")
+    void notFound() {
+        Order order = paymentPendingOrder();
+        PaymentReconciliation r = PaymentReconciliation.enqueue(order.getId().value(), Instant.now());
+        when(walletPaymentPort.getUsage(order.getId().value())).thenReturn(
+                new UsageStatus(order.getId().value(), UsageStatus.Result.NOT_FOUND,
+                        null, null, null, null));
+        when(orderRepository.findByIdOrThrow(order.getId())).thenReturn(order);
+
+        processor.processOne(r);
+
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.REQUESTED);
+        assertThat(r.getStatus()).isEqualTo(ReconciliationStatus.DONE);
+    }
+
+    @Test
+    @DisplayName("getUsage 실패 — recordUnknown (retry_count++), 알림 X (아직 PENDING)")
+    void unknown_keepPending() {
+        UUID orderId = UUID.randomUUID();
+        PaymentReconciliation r = PaymentReconciliation.enqueue(orderId, Instant.now());
+        when(walletPaymentPort.getUsage(orderId)).thenThrow(new WalletCommunicationException());
+
+        processor.processOne(r);
+
+        assertThat(r.getStatus()).isEqualTo(ReconciliationStatus.PENDING);
+        assertThat(r.getRetryCount()).isEqualTo(1);
+        verify(reconciliationRepository).save(r);
+        verify(alertPort, never()).notifyGivenUp(any(), anyInt(), any());
+    }
+
+    @Test
+    @DisplayName("getUsage 실패 — retry_count 가 MAX 도달 시 GIVEN_UP + 알림")
+    void unknown_givenUp() {
+        UUID orderId = UUID.randomUUID();
+        PaymentReconciliation r = PaymentReconciliation.enqueue(orderId, Instant.now());
+        r.recordUnknown("e1", Instant.now());     // count=1
+        r.recordUnknown("e2", Instant.now());     // count=2
+        when(walletPaymentPort.getUsage(orderId)).thenThrow(new WalletCommunicationException());
+
+        processor.processOne(r);                   // count → 3 → GIVEN_UP
+
+        assertThat(r.getStatus()).isEqualTo(ReconciliationStatus.GIVEN_UP);
+        verify(alertPort).notifyGivenUp(eq(orderId), eq(PaymentReconciliation.MAX_RETRIES), any());
+    }
+
+    @Test
+    @DisplayName("DEDUCTED 인데 order 가 이미 PAID — 멱등 처리 (markPaid 호출 X)")
+    void deducted_alreadyPaid() {
+        Order order = OrderTestFixtures.paidOrder(UUID.randomUUID(), UUID.randomUUID());
+        PaymentReconciliation r = PaymentReconciliation.enqueue(order.getId().value(), Instant.now());
+        when(walletPaymentPort.getUsage(order.getId().value())).thenReturn(
+                new UsageStatus(order.getId().value(), UsageStatus.Result.DEDUCTED,
+                        100_000L, 50_000L, null, Instant.now()));
+        when(orderRepository.findByIdOrThrow(order.getId())).thenReturn(order);
+
+        processor.processOne(r);
+
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.PAID);
+        assertThat(r.getStatus()).isEqualTo(ReconciliationStatus.DONE);
+        // 이미 PAID 라 save / outbox 호출 X
+        verify(orderRepository, never()).save(any(Order.class));
+    }
+
+    // helper — PAYMENT_PENDING 상태 order 생성.
+    private Order paymentPendingOrder() {
+        Order order = OrderTestFixtures.requestedOrder();
+        order.requestPayment();    // REQUESTED → PAYMENT_PENDING
+        return order;
+    }
+
+    // Mockito ArgumentMatchers 헬퍼 static import 누락 회피 — 메서드 정의로 대체.
+    private static <T> T eq(T value) { return org.mockito.ArgumentMatchers.eq(value); }
+    private static int anyInt() { return org.mockito.ArgumentMatchers.anyInt(); }
+}

--- a/src/test/java/com/trustamarket/orderservice/order/domain/model/PaymentReconciliationTest.java
+++ b/src/test/java/com/trustamarket/orderservice/order/domain/model/PaymentReconciliationTest.java
@@ -1,0 +1,90 @@
+package com.trustamarket.orderservice.order.domain.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PaymentReconciliationTest {
+
+    @Test
+    @DisplayName("enqueue — PENDING, retry_count=0, next_retry_at=NOW+30s")
+    void enqueue() {
+        UUID orderId = UUID.randomUUID();
+        Instant now = Instant.parse("2026-06-03T00:00:00Z");
+
+        PaymentReconciliation r = PaymentReconciliation.enqueue(orderId, now);
+
+        assertThat(r.getOrderId()).isEqualTo(orderId);
+        assertThat(r.getStatus()).isEqualTo(ReconciliationStatus.PENDING);
+        assertThat(r.getRetryCount()).isZero();
+        assertThat(r.getNextRetryAt()).isEqualTo(now.plus(Duration.ofSeconds(30)));
+        assertThat(r.getLastAttemptAt()).isNull();
+        assertThat(r.getLastError()).isNull();
+    }
+
+    @Test
+    @DisplayName("markDone — DONE 으로 전이 + lastAttemptAt 갱신")
+    void markDone() {
+        PaymentReconciliation r = PaymentReconciliation.enqueue(UUID.randomUUID(), Instant.now());
+        Instant t = Instant.parse("2026-06-03T00:01:00Z");
+
+        r.markDone(t);
+
+        assertThat(r.getStatus()).isEqualTo(ReconciliationStatus.DONE);
+        assertThat(r.getLastAttemptAt()).isEqualTo(t);
+    }
+
+    @Test
+    @DisplayName("recordUnknown 1회 — retry_count=1, next_retry_at=NOW+60s (BACKOFFS[1])")
+    void recordUnknown_first() {
+        PaymentReconciliation r = PaymentReconciliation.enqueue(UUID.randomUUID(), Instant.now());
+        Instant t = Instant.parse("2026-06-03T00:01:00Z");
+
+        r.recordUnknown("timeout", t);
+
+        assertThat(r.getStatus()).isEqualTo(ReconciliationStatus.PENDING);
+        assertThat(r.getRetryCount()).isEqualTo(1);
+        assertThat(r.getNextRetryAt()).isEqualTo(t.plus(Duration.ofSeconds(60)));
+        assertThat(r.getLastAttemptAt()).isEqualTo(t);
+        assertThat(r.getLastError()).isEqualTo("timeout");
+    }
+
+    @Test
+    @DisplayName("recordUnknown 2회 — retry_count=2, next_retry_at=NOW+120s (BACKOFFS[2])")
+    void recordUnknown_second() {
+        PaymentReconciliation r = PaymentReconciliation.enqueue(UUID.randomUUID(), Instant.now());
+        r.recordUnknown("e1", Instant.parse("2026-06-03T00:01:00Z"));
+        Instant t = Instant.parse("2026-06-03T00:02:00Z");
+
+        r.recordUnknown("e2", t);
+
+        assertThat(r.getStatus()).isEqualTo(ReconciliationStatus.PENDING);
+        assertThat(r.getRetryCount()).isEqualTo(2);
+        assertThat(r.getNextRetryAt()).isEqualTo(t.plus(Duration.ofSeconds(120)));
+    }
+
+    @Test
+    @DisplayName("recordUnknown 3회 도달 — GIVEN_UP 전이, next_retry_at 갱신 X")
+    void recordUnknown_givenUp() {
+        PaymentReconciliation r = PaymentReconciliation.enqueue(UUID.randomUUID(), Instant.now());
+        Instant beforeGivenUp = r.getNextRetryAt();
+        r.recordUnknown("e1", Instant.parse("2026-06-03T00:01:00Z"));
+        r.recordUnknown("e2", Instant.parse("2026-06-03T00:02:00Z"));
+        Instant nextRetryBefore = r.getNextRetryAt();
+
+        r.recordUnknown("e3", Instant.parse("2026-06-03T00:03:00Z"));
+
+        assertThat(r.getStatus()).isEqualTo(ReconciliationStatus.GIVEN_UP);
+        assertThat(r.getRetryCount()).isEqualTo(PaymentReconciliation.MAX_RETRIES);
+        assertThat(r.getLastError()).isEqualTo("e3");
+        // GIVEN_UP 이후 next_retry_at 변경 X (스케줄러가 picking 안 함)
+        assertThat(r.getNextRetryAt()).isEqualTo(nextRetryBefore);
+        // 시작 시점의 next_retry_at 도 동일 (compile/sanity)
+        assertThat(beforeGivenUp).isNotNull();
+    }
+}


### PR DESCRIPTION
## 🌱 설명

결제 saga 의 wallet Feign 호출이 timeout / 5xx 등 비정상 응답을 받았을 때 결과를 모르고 무조건 보상하던 문제 해결.

토스 외화 환전 사례와 팀 논의를 참고해 **결과 재확인 + DB queue 백오프 재시도** 패턴 도입.

> 1-step saga 이므로 외부 변경을 되돌리는 **보상 트랜잭션은 없음**. NOT_FOUND / INSUFFICIENT 는 wallet 에 외부 변경이 없으므로 order 상태 복귀만 수행.

## 📌 관련 이슈

close #56

## ✅ 주요 변경 사항

- Liquibase `007-create-p-payment-reconciliation.yaml` — 재시도 큐 테이블
- 도메인 `PaymentReconciliation` + `ReconciliationStatus(PENDING/DONE/GIVEN_UP)` + 백오프 정책 (30s → 60s → 120s, MAX 3)
- 영속화 — `PaymentReconciliationJpaEntity` (BaseUserEntity), Mapper, JpaRepository, Adapter
- `WalletPaymentPort.getUsage(orderId)` + `UsageStatus(DEDUCTED / INSUFFICIENT / NOT_FOUND)` 추가 — Feign Client / Adapter 반영
- `RequestPaymentService` catch 분기 강화 — `WalletCommunicationException` 잡아 `handleUnknownResult` 로 재확인 → 3-way 처리
  - DEDUCTED → markPaid (응답만 손실된 케이스)
  - INSUFFICIENT → rollbackToRequested + `InsufficientPointBalanceException`
  - NOT_FOUND → rollbackToRequested + `WalletCommunicationException`
  - getUsage 도 실패 → `reconciliationRepository.enqueueIfAbsent` + `PaymentVerificationPendingException` (HTTP 202, "결제 처리 중")
- `PaymentReconciliationScheduler` (`fixedDelay=10_000`) + `PaymentReconciliationProcessor`
  - Feign 호출은 tx 밖, DB UPDATE 만 짧은 tx 안 (HikariCP 점유 시간 최소화)
  - 결과 도착 시 markPaid / rollbackToRequested + reconciliation `markDone`
  - getUsage 또 실패 시 `recordUnknown` (백오프), MAX 도달 시 GIVEN_UP + 알림
  - 이미 PAID / REQUESTED 면 멱등 처리
- `ReconciliationAlertPort` + `ReconciliationAlertAdapter` — notification-service `/api/v1/alerts/webhook` (AlertManager 포맷) 로 GIVEN_UP 알림 발송
- 신규 예외 `PaymentVerificationPendingException` (202 Accepted)
- 테스트 — 도메인 (백오프/GIVEN_UP), Processor (4-way 분기 + 멱등), saga catch 4-way 분기

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

- **wallet 측 API 미완성** — `GET /internal/v1/wallets/usages/{orderId}` 는 wallet 팀원 작업. 호출 시그니처만 합의할 spec 으로 정의했고 단위 테스트는 mock 으로 통과. 머지 후 wallet 측 endpoint 가 붙으면 동작 시작.
- **wallet 측 추가 요청** — 잔액 부족으로 거절한 시도도 `p_point_transaction_request_history` 등에 `REJECTED` 로 기록해야 INSUFFICIENT 구분 가능. 안 되면 모두 NOT_FOUND 로 처리되며 UX 메시지만 단조로워짐 (기능엔 영향 X).
- **Scheduler 주기 10초 / 배치 50건** — 정상 흐름에서 PENDING row 거의 0 → 빈 SELECT 6회/분. 부담 무시 가능.
- **Discord 실제 발송 검증은 후속** — notification-service feign / adapter 까지 작성하고 단위 테스트 통과. 실제 Discord webhook 발송은 별도 검증 예정.
- **노션**: 결제 사가 패턴 (개발 기록 보드)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 결제 재확인 자동 재시도 메커니즘 도입(최대 3회, 지수 백오프) 및 재조정 도메인·큐잉 추가
  * 주문 단위 지갑 사용(차감) 상태 동기 조회 기능 추가 및 재확인 실패 시 재시도 큐 적재
  * 재확인 실패 임계 시 운영자 알림 전송(베스트 이포트)
  * 10초 간격 자동 재확인 스케줄러 및 단건 처리기 추가
  * 지갑 차감 요청에 idempotencyKey 도입 및 요청 검증 강화

* **데이터베이스**
  * 결제 재조정 상태 추적용 테이블 및 관련 인덱스 추가

* **테스트**
  * 다양한 재확인/예외/재시도 시나리오에 대한 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->